### PR TITLE
fix: Pull general accounts alongside market specific

### DIFF
--- a/vega_sim/api/data.py
+++ b/vega_sim/api/data.py
@@ -22,16 +22,15 @@ def party_account(
     account_req = data_node_protos.trading_data.PartyAccountsRequest(
         party_id=pub_key,
         asset=asset_id,
-        market_id=market_id,
-    )
-    general_account_req = data_node_protos.trading_data.PartyAccountsRequest(
-        party_id=pub_key,
-        asset_id=asset_id,
     )
     accounts = data_client.PartyAccounts(account_req).accounts
-    general_accounts = data_client.PartyAccounts(general_account_req).accounts
+
     general, margin, bond = np.nan, np.nan, np.nan
-    for account in accounts + general_accounts:
+    for account in accounts:
+        if account.market_id and account.market_id != market_id:
+            # The 'general' account type has no market ID, so we have to pull
+            # all markets then filter down here
+            continue
         if account.type == vega_protos.vega.ACCOUNT_TYPE_GENERAL:
             general = float(account.balance)
         if account.type == vega_protos.vega.ACCOUNT_TYPE_MARGIN:


### PR DESCRIPTION
### Description

In order to fully populate the list of party accounts we need to request with no market ID (as general account is removed if we filter in request) then filter the response.