### PR TITLE
fix: Improve process handling with a context manager

### DIFF
--- a/vega_sim/null_service.py
+++ b/vega_sim/null_service.py
@@ -424,6 +424,13 @@ class VegaServiceNull(VegaService):
         if start_immediately:
             self.start()
 
+    def __enter__(self):
+        self.start()
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self.stop()
+
     def _assign_ports(self):
         self.wallet_port = 0
         self.data_node_rest_port = 0
@@ -464,7 +471,6 @@ class VegaServiceNull(VegaService):
                 "run_wallet_with_console": self.run_wallet_with_console,
                 "port_config": self._generate_port_config(),
             },
-            daemon=True,
         )
         self.proc.start()
 


### PR DESCRIPTION
### Description

Creating a context manager for Vega Sim instances, allowing one to use the service in two ways:

1) Manually starting and stopping:
```
vega = VegaServiceNull()
vega.start()
# Do things
vega.stop() 
```

2) In a context
```
with VegaServiceNull() as vega:
    # Do things
```

This new content manager ensures processes are properly killed on exit.