### PR TITLE
Fix the issue of converting price to padded int when submitting market orders while the price would be None

### DIFF
--- a/vega_sim/service.py
+++ b/vega_sim/service.py
@@ -408,7 +408,9 @@ class VegaService(ABC):
                 data.market_price_decimals(
                     market_id, data_client=self.trading_data_client()
                 ),
-            ),
+            )
+            if price is not None
+            else None,
             expires_at=expires_at,
             pegged_order=pegged_order,
             wait=wait,


### PR DESCRIPTION
Fix the issue of converting price to padded int when submitting market orders while the price would be None