### PR TITLE
Fix the position decimal issue when posting market orders

### DIFF
--- a/vega_sim/service.py
+++ b/vega_sim/service.py
@@ -405,10 +405,7 @@ class VegaService(ABC):
             time_in_force="TIME_IN_FORCE_FOK" if fill_or_kill else "TIME_IN_FORCE_IOC",
             order_type="TYPE_MARKET",
             side=side,
-            volume=num_to_padded_int(
-                volume,
-                self.market_pos_decimals[market_id],
-            ),
+            volume=volume,
             wait=wait,
             order_ref=order_ref,
         )


### PR DESCRIPTION
When using `submit_order` function, the volume will be padded into int, so we do not need to convert again in function `submit_market_order`.  