### PR TITLE
feat: Adding order stream api and tests

### DIFF
--- a/examples/nullchain.py
+++ b/examples/nullchain.py
@@ -25,7 +25,7 @@ wallets = [MM_WALLET, MM_WALLET2, TRADER_WALLET, RANDOM_WALLET, TERMINATE_WALLET
 if __name__ == "__main__":
     logging.basicConfig(level=logging.INFO)
 
-    with VegaServiceNull(run_with_console=True) as vega:
+    with VegaServiceNull(run_with_console=False, start_order_feed=False) as vega:
 
         for wallet in wallets:
             vega.create_wallet(wallet.name, wallet.passphrase)
@@ -165,7 +165,10 @@ if __name__ == "__main__":
         #     sell_specs=[("PEGGED_REFERENCE_MID", i * 2, i) for i in range(1, 10)],
         #     is_amendment=False,
         # )
+        vega.start_order_monitoring()
+        import pdb
 
+        pdb.set_trace()
         vega.forward("10s")
         vega.settle_market(
             settlement_wallet=TERMINATE_WALLET.name,

--- a/examples/nullchain.py
+++ b/examples/nullchain.py
@@ -165,10 +165,6 @@ if __name__ == "__main__":
         #     sell_specs=[("PEGGED_REFERENCE_MID", i * 2, i) for i in range(1, 10)],
         #     is_amendment=False,
         # )
-        vega.start_order_monitoring()
-        import pdb
-
-        pdb.set_trace()
         vega.forward("10s")
         vega.settle_market(
             settlement_wallet=TERMINATE_WALLET.name,

--- a/tests/vega_sim/api/test_data.py
+++ b/tests/vega_sim/api/test_data.py
@@ -183,6 +183,7 @@ def test_open_orders_by_market(trading_data_servicer_and_port):
             orders=[
                 vega_protos.vega.Order(
                     id="id1",
+                    market_id="market",
                     status=vega_protos.vega.Order.Status.STATUS_ACTIVE,
                     reference="ref1",
                     side=vega_protos.vega.SIDE_BUY,
@@ -199,6 +200,7 @@ def test_open_orders_by_market(trading_data_servicer_and_port):
                 ),
                 vega_protos.vega.Order(
                     id="id2",
+                    market_id="market",
                     status=vega_protos.vega.Order.Status.STATUS_CANCELLED,
                     reference="ref1",
                     side=vega_protos.vega.SIDE_BUY,
@@ -215,6 +217,7 @@ def test_open_orders_by_market(trading_data_servicer_and_port):
                 ),
                 vega_protos.vega.Order(
                     id="id3",
+                    market_id="market",
                     status=vega_protos.vega.Order.Status.STATUS_FILLED,
                     reference="ref1",
                     side=vega_protos.vega.SIDE_BUY,
@@ -231,6 +234,7 @@ def test_open_orders_by_market(trading_data_servicer_and_port):
                 ),
                 vega_protos.vega.Order(
                     id="id4",
+                    market_id="market",
                     status=vega_protos.vega.Order.Status.STATUS_ACTIVE,
                     reference="ref1",
                     side=vega_protos.vega.SIDE_BUY,
@@ -247,6 +251,7 @@ def test_open_orders_by_market(trading_data_servicer_and_port):
                 ),
                 vega_protos.vega.Order(
                     id="id5",
+                    market_id="market",
                     status=vega_protos.vega.Order.Status.STATUS_ACTIVE,
                     reference="ref1",
                     side=vega_protos.vega.SIDE_BUY,
@@ -263,6 +268,7 @@ def test_open_orders_by_market(trading_data_servicer_and_port):
                 ),
                 vega_protos.vega.Order(
                     id="id6",
+                    market_id="market",
                     status=vega_protos.vega.Order.Status.STATUS_ACTIVE,
                     reference="ref1",
                     side=vega_protos.vega.SIDE_SELL,
@@ -279,6 +285,7 @@ def test_open_orders_by_market(trading_data_servicer_and_port):
                 ),
                 vega_protos.vega.Order(
                     id="id7",
+                    market_id="market",
                     status=vega_protos.vega.Order.Status.STATUS_ACTIVE,
                     reference="ref1",
                     side=vega_protos.vega.SIDE_SELL,
@@ -314,6 +321,7 @@ def test_open_orders_by_market(trading_data_servicer_and_port):
         bids=[
             Order(
                 id="id1",
+                market_id="market",
                 status=vega_protos.vega.Order.Status.STATUS_ACTIVE,
                 reference="ref1",
                 side=vega_protos.vega.SIDE_BUY,
@@ -330,6 +338,7 @@ def test_open_orders_by_market(trading_data_servicer_and_port):
             ),
             Order(
                 id="id4",
+                market_id="market",
                 status=vega_protos.vega.Order.Status.STATUS_ACTIVE,
                 reference="ref1",
                 side=vega_protos.vega.SIDE_BUY,
@@ -346,6 +355,7 @@ def test_open_orders_by_market(trading_data_servicer_and_port):
             ),
             Order(
                 id="id5",
+                market_id="market",
                 status=vega_protos.vega.Order.Status.STATUS_ACTIVE,
                 reference="ref1",
                 side=vega_protos.vega.SIDE_BUY,
@@ -364,6 +374,7 @@ def test_open_orders_by_market(trading_data_servicer_and_port):
         asks=[
             Order(
                 id="id6",
+                market_id="market",
                 status=vega_protos.vega.Order.Status.STATUS_ACTIVE,
                 reference="ref1",
                 side=vega_protos.vega.SIDE_SELL,
@@ -380,6 +391,7 @@ def test_open_orders_by_market(trading_data_servicer_and_port):
             ),
             Order(
                 id="id7",
+                market_id="market",
                 status=vega_protos.vega.Order.Status.STATUS_ACTIVE,
                 reference="ref1",
                 side=vega_protos.vega.SIDE_SELL,
@@ -408,6 +420,7 @@ def test_order_subscription(
     orders = [
         vega_protos.vega.Order(
             id="id1",
+            market_id="market",
             status=vega_protos.vega.Order.Status.STATUS_ACTIVE,
             reference="ref1",
             side=vega_protos.vega.SIDE_BUY,
@@ -424,6 +437,7 @@ def test_order_subscription(
         ),
         vega_protos.vega.Order(
             id="id2",
+            market_id="market",
             status=vega_protos.vega.Order.Status.STATUS_CANCELLED,
             reference="ref1",
             side=vega_protos.vega.SIDE_BUY,
@@ -440,6 +454,7 @@ def test_order_subscription(
         ),
         vega_protos.vega.Order(
             id="id3",
+            market_id="market",
             status=vega_protos.vega.Order.Status.STATUS_FILLED,
             reference="ref1",
             side=vega_protos.vega.SIDE_BUY,
@@ -456,6 +471,7 @@ def test_order_subscription(
         ),
         vega_protos.vega.Order(
             id="id4",
+            market_id="market",
             status=vega_protos.vega.Order.Status.STATUS_ACTIVE,
             reference="ref1",
             side=vega_protos.vega.SIDE_BUY,
@@ -472,6 +488,7 @@ def test_order_subscription(
         ),
         vega_protos.vega.Order(
             id="id5",
+            market_id="market",
             status=vega_protos.vega.Order.Status.STATUS_ACTIVE,
             reference="ref1",
             side=vega_protos.vega.SIDE_BUY,
@@ -488,6 +505,7 @@ def test_order_subscription(
         ),
         vega_protos.vega.Order(
             id="id6",
+            market_id="market",
             status=vega_protos.vega.Order.Status.STATUS_ACTIVE,
             reference="ref1",
             side=vega_protos.vega.SIDE_SELL,
@@ -504,6 +522,7 @@ def test_order_subscription(
         ),
         vega_protos.vega.Order(
             id="id7",
+            market_id="market",
             status=vega_protos.vega.Order.Status.STATUS_ACTIVE,
             reference="ref1",
             side=vega_protos.vega.SIDE_SELL,

--- a/tests/vega_sim/api/test_data_raw.py
+++ b/tests/vega_sim/api/test_data_raw.py
@@ -380,6 +380,7 @@ def test_order_subscription(trading_data_servicer_and_port):
         orders = [
             vega_protos.vega.Order(
                 id="id1",
+                market_id="market",
                 status=vega_protos.vega.Order.Status.STATUS_ACTIVE,
                 reference="ref1",
                 side=vega_protos.vega.SIDE_BUY,
@@ -396,6 +397,7 @@ def test_order_subscription(trading_data_servicer_and_port):
             ),
             vega_protos.vega.Order(
                 id="id2",
+                market_id="market",
                 status=vega_protos.vega.Order.Status.STATUS_CANCELLED,
                 reference="ref1",
                 side=vega_protos.vega.SIDE_BUY,
@@ -412,6 +414,7 @@ def test_order_subscription(trading_data_servicer_and_port):
             ),
             vega_protos.vega.Order(
                 id="id3",
+                market_id="market",
                 status=vega_protos.vega.Order.Status.STATUS_FILLED,
                 reference="ref1",
                 side=vega_protos.vega.SIDE_BUY,
@@ -428,6 +431,7 @@ def test_order_subscription(trading_data_servicer_and_port):
             ),
             vega_protos.vega.Order(
                 id="id4",
+                market_id="market",
                 status=vega_protos.vega.Order.Status.STATUS_ACTIVE,
                 reference="ref1",
                 side=vega_protos.vega.SIDE_BUY,
@@ -444,6 +448,7 @@ def test_order_subscription(trading_data_servicer_and_port):
             ),
             vega_protos.vega.Order(
                 id="id5",
+                market_id="market",
                 status=vega_protos.vega.Order.Status.STATUS_ACTIVE,
                 reference="ref1",
                 side=vega_protos.vega.SIDE_BUY,
@@ -460,6 +465,7 @@ def test_order_subscription(trading_data_servicer_and_port):
             ),
             vega_protos.vega.Order(
                 id="id6",
+                market_id="market",
                 status=vega_protos.vega.Order.Status.STATUS_ACTIVE,
                 reference="ref1",
                 side=vega_protos.vega.SIDE_SELL,
@@ -476,6 +482,7 @@ def test_order_subscription(trading_data_servicer_and_port):
             ),
             vega_protos.vega.Order(
                 id="id7",
+                market_id="market",
                 status=vega_protos.vega.Order.Status.STATUS_ACTIVE,
                 reference="ref1",
                 side=vega_protos.vega.SIDE_SELL,

--- a/tests/vega_sim/api/test_data_raw.py
+++ b/tests/vega_sim/api/test_data_raw.py
@@ -20,6 +20,7 @@ from vega_sim.api.data_raw import (
     market_info,
     order_status,
     positions_by_market,
+    order_subscription,
     order_status_by_reference,
 )
 from vega_sim.proto.data_node.api.v1.trading_data_pb2_grpc import (
@@ -372,3 +373,144 @@ def test_liquidity_provisions(trading_data_servicer_and_port):
     )
 
     assert res[0].market_id == "MARKET"
+
+
+def test_order_subscription(trading_data_servicer_and_port):
+    def OrdersSubscribe(self, request, context):
+        orders = [
+            vega_protos.vega.Order(
+                id="id1",
+                status=vega_protos.vega.Order.Status.STATUS_ACTIVE,
+                reference="ref1",
+                side=vega_protos.vega.SIDE_BUY,
+                price="10100",
+                size=101,
+                remaining=101,
+                time_in_force=vega_protos.vega.Order.TimeInForce.TIME_IN_FORCE_GTC,
+                type=vega_protos.vega.Order.Type.TYPE_LIMIT,
+                created_at=1653266950,
+                expires_at=1653276950,
+                party_id="party1",
+                updated_at=1653266950,
+                version=1,
+            ),
+            vega_protos.vega.Order(
+                id="id2",
+                status=vega_protos.vega.Order.Status.STATUS_CANCELLED,
+                reference="ref1",
+                side=vega_protos.vega.SIDE_BUY,
+                price="10100",
+                size=101,
+                remaining=101,
+                time_in_force=vega_protos.vega.Order.TimeInForce.TIME_IN_FORCE_GTC,
+                type=vega_protos.vega.Order.Type.TYPE_LIMIT,
+                created_at=1653266950,
+                expires_at=1653276950,
+                party_id="party1",
+                updated_at=1653266950,
+                version=1,
+            ),
+            vega_protos.vega.Order(
+                id="id3",
+                status=vega_protos.vega.Order.Status.STATUS_FILLED,
+                reference="ref1",
+                side=vega_protos.vega.SIDE_BUY,
+                price="10100",
+                size=101,
+                remaining=0,
+                time_in_force=vega_protos.vega.Order.TimeInForce.TIME_IN_FORCE_GTC,
+                type=vega_protos.vega.Order.Type.TYPE_LIMIT,
+                created_at=1653266950,
+                expires_at=1653276950,
+                party_id="party1",
+                updated_at=1653266950,
+                version=1,
+            ),
+            vega_protos.vega.Order(
+                id="id4",
+                status=vega_protos.vega.Order.Status.STATUS_ACTIVE,
+                reference="ref1",
+                side=vega_protos.vega.SIDE_BUY,
+                price="10110",
+                size=101,
+                remaining=101,
+                time_in_force=vega_protos.vega.Order.TimeInForce.TIME_IN_FORCE_GTC,
+                type=vega_protos.vega.Order.Type.TYPE_LIMIT,
+                created_at=1653266950,
+                expires_at=1653276950,
+                party_id="party1",
+                updated_at=1653266950,
+                version=1,
+            ),
+            vega_protos.vega.Order(
+                id="id5",
+                status=vega_protos.vega.Order.Status.STATUS_ACTIVE,
+                reference="ref1",
+                side=vega_protos.vega.SIDE_BUY,
+                price="10100",
+                size=101,
+                remaining=101,
+                time_in_force=vega_protos.vega.Order.TimeInForce.TIME_IN_FORCE_GTC,
+                type=vega_protos.vega.Order.Type.TYPE_LIMIT,
+                created_at=1653266950,
+                expires_at=1653276950,
+                party_id="party2",
+                updated_at=1653266950,
+                version=1,
+            ),
+            vega_protos.vega.Order(
+                id="id6",
+                status=vega_protos.vega.Order.Status.STATUS_ACTIVE,
+                reference="ref1",
+                side=vega_protos.vega.SIDE_SELL,
+                price="10400",
+                size=111,
+                remaining=121,
+                time_in_force=vega_protos.vega.Order.TimeInForce.TIME_IN_FORCE_GTC,
+                type=vega_protos.vega.Order.Type.TYPE_LIMIT,
+                created_at=1653266950,
+                expires_at=1653276950,
+                party_id="party1",
+                updated_at=1653266950,
+                version=1,
+            ),
+            vega_protos.vega.Order(
+                id="id7",
+                status=vega_protos.vega.Order.Status.STATUS_ACTIVE,
+                reference="ref1",
+                side=vega_protos.vega.SIDE_SELL,
+                price="10100",
+                size=101,
+                remaining=101,
+                time_in_force=vega_protos.vega.Order.TimeInForce.TIME_IN_FORCE_GTC,
+                type=vega_protos.vega.Order.Type.TYPE_LIMIT,
+                created_at=1653266950,
+                expires_at=1653276950,
+                party_id="party1",
+                updated_at=1653266950,
+                version=1,
+            ),
+        ]
+        for order_chunk in [orders[:3], orders[3:6], orders[6:]]:
+            yield data_node_protos.trading_data.OrdersSubscribeResponse(
+                orders=order_chunk
+            )
+
+    server, port, mock_servicer = trading_data_servicer_and_port
+    mock_servicer.OrdersSubscribe = OrdersSubscribe
+
+    add_TradingDataServiceServicer_to_server(mock_servicer(), server)
+
+    data_client = VegaTradingDataClient(f"localhost:{port}")
+
+    queue = order_subscription(
+        data_client=data_client,
+    )
+
+    batch_one = next(queue)
+    batch_two = next(queue)
+    batch_three = next(queue)
+
+    assert len(batch_one.orders) == 3
+    assert len(batch_two.orders) == 3
+    assert len(batch_three.orders) == 1

--- a/tests/vega_sim/test_service.py
+++ b/tests/vega_sim/test_service.py
@@ -1,4 +1,5 @@
 import json
+from typing import Optional
 import pytest
 import requests_mock
 
@@ -19,6 +20,11 @@ class StubService(VegaService):
     @property
     def wallet(self):
         return self._wallet
+
+    def start_order_monitoring(
+        self, market_id: Optional[str] = None, party_id: Optional[str] = None
+    ):
+        pass
 
 
 @pytest.fixture

--- a/vega_sim/api/data.py
+++ b/vega_sim/api/data.py
@@ -313,7 +313,7 @@ def all_orders(
 
     output_orders = []
     for order in orders:
-        if order.market_id not in mkt_pos_dp:
+        if price_decimals is None and order.market_id not in mkt_price_dp:
             mkt_pos_dp[order.market_id] = market_position_decimals(
                 market_id=order.market_id, data_client=data_client
             )

--- a/vega_sim/api/data.py
+++ b/vega_sim/api/data.py
@@ -1,19 +1,22 @@
-from dataclasses import dataclass
-import numpy as np
+import logging
+import threading
 from collections import namedtuple
-from typing import Callable, List, Optional, Tuple, TypeVar
+from dataclasses import dataclass
+from queue import Queue
+from typing import Callable, DefaultDict, Iterable, List, Optional, Tuple, TypeVar
 
-
+import vega_sim.api.data_raw as data_raw
 import vega_sim.grpc.client as vac
 import vega_sim.proto.data_node.api.v1 as data_node_protos
 import vega_sim.proto.vega as vega_protos
-import vega_sim.api.data_raw as data_raw
 from vega_sim.api.helpers import num_from_padded_int
 
 
 class MissingAssetError(Exception):
     pass
 
+
+logger = logging.Logger(__name__)
 
 T = TypeVar("T")
 S = TypeVar("S")
@@ -36,6 +39,7 @@ Order = namedtuple(
         "created_at",
         "expires_at",
         "party_id",
+        "market_id",
         "updated_at",
         "version",
     ],
@@ -89,6 +93,7 @@ def _order_from_proto(
         party_id=order.party_id,
         updated_at=order.updated_at,
         version=order.version,
+        market_id=order.market_id,
     )
 
 
@@ -255,37 +260,76 @@ def open_orders_by_market(
     Returns:
         OrdersBySide, Live orders segregated by side
     """
+    bids = []
+    asks = []
+    orders = all_orders(
+        market_id=market_id,
+        data_client=data_client,
+        price_decimals=price_decimals,
+        position_decimals=position_decimals,
+        open_only=True,
+    )
+    for order in orders:
+        bids.append(order) if order.side == vega_protos.vega.SIDE_BUY else asks.append(
+            order
+        )
+
+    return OrdersBySide(bids, asks)
+
+
+def all_orders(
+    market_id: str,
+    data_client: vac.VegaTradingDataClient,
+    price_decimals: Optional[int] = None,
+    position_decimals: Optional[int] = None,
+    open_only: bool = False,
+) -> OrdersBySide:
+    """
+    Output all active limit orders in current market.
+
+    Args:
+        market_id:
+            str, ID for the market to load
+        data_client:
+            VegaTradingDataClient, instantiated gRPC client
+        open_only:
+            bool, default False, whether to only return still
+                open orders
+
+    Returns:
+        OrdersBySide, Live orders segregated by side
+    """
     orders = _unroll_pagination(
         data_node_protos.trading_data.OrdersByMarketRequest(market_id=market_id),
         lambda x: data_client.OrdersByMarket(x).orders,
     )
 
     mkt_price_dp = (
-        price_decimals
-        if price_decimals is not None
-        else market_price_decimals(market_id=market_id, data_client=data_client)
+        DefaultDict(lambda: price_decimals) if price_decimals is not None else {}
     )
     mkt_pos_dp = (
-        position_decimals
-        if position_decimals is not None
-        else market_position_decimals(market_id=market_id, data_client=data_client)
+        DefaultDict(lambda: position_decimals) if position_decimals is not None else {}
     )
 
-    bids = []
-    asks = []
+    output_orders = []
     for order in orders:
-        if order.status != vega_protos.vega.Order.Status.STATUS_ACTIVE:
+        if order.market_id not in mkt_pos_dp:
+            mkt_pos_dp[order.market_id] = market_position_decimals(
+                market_id=order.market_id, data_client=data_client
+            )
+            mkt_price_dp[order.market_id] = market_price_decimals(
+                market_id=order.market_id, data_client=data_client
+            )
+
+        if open_only and order.status != vega_protos.vega.Order.Status.STATUS_ACTIVE:
             continue
         converted_order = _order_from_proto(
-            order, price_decimals=mkt_price_dp, position_decimals=mkt_pos_dp
+            order,
+            price_decimals=mkt_price_dp[order.market_id],
+            position_decimals=mkt_pos_dp[order.market_id],
         )
-        bids.append(
-            converted_order
-        ) if converted_order.side == vega_protos.vega.SIDE_BUY else asks.append(
-            converted_order
-        )
-
-    return OrdersBySide(bids, asks)
+        output_orders.append(converted_order)
+    return output_orders
 
 
 def order_book_by_market(
@@ -425,3 +469,64 @@ def market_depth(
         buys=[_price_level_from_raw(level) for level in mkt_depth.buy],
         sells=[_price_level_from_raw(level) for level in mkt_depth.sell],
     )
+
+
+def order_subscription(
+    data_client: vac.VegaTradingDataClient,
+    market_id: Optional[str] = None,
+    party_id: Optional[str] = None,
+) -> Queue[Order]:
+    """Subscribe to a stream of Order updates from the data-node.
+    The stream of orders returned from this function is an iterable which
+    does not end and will continue to tick another order update whenever
+    one is received.
+
+    Args:
+        market_id:
+            Optional[str], If provided, only update orders from this market
+        party_id:
+            Optional[str], If provided, only update orders from this party
+    Returns:
+        Iterable[Order], Infinite iterable of order updates
+    """
+
+    queue = Queue()
+
+    order_stream = data_raw.order_subscription(
+        data_client=data_client, market_id=market_id, party_id=party_id
+    )
+
+    threading.Thread(
+        target=_queue_thread, args=(queue, order_stream, data_client)
+    ).start()
+
+    return queue
+
+
+def _queue_thread(
+    queue: Queue,
+    order_stream: Iterable[vega_protos.vega.Order],
+    data_client: vac.VegaTradingDataClient,
+):
+    mkt_pos_dp = {}
+    mkt_price_dp = {}
+    try:
+        for order_list in order_stream:
+            for order in order_list.orders:
+                if order.market_id not in mkt_pos_dp:
+                    mkt_pos_dp[order.market_id] = market_position_decimals(
+                        market_id=order.market_id, data_client=data_client
+                    )
+                    mkt_price_dp[order.market_id] = market_price_decimals(
+                        market_id=order.market_id, data_client=data_client
+                    )
+                queue.put(
+                    _order_from_proto(
+                        order,
+                        mkt_price_dp[order.market_id],
+                        mkt_pos_dp[order.market_id],
+                    )
+                )
+    except Exception as e:
+        logger.info("Order subscription closed")
+        return

--- a/vega_sim/api/data_raw.py
+++ b/vega_sim/api/data_raw.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from collections import namedtuple
-from typing import Dict, List, Optional
+from queue import Queue
+import threading
+from typing import Dict, Iterable, List, Optional
 
 import vega_sim.grpc.client as vac
 import vega_sim.proto.data_node.api.v1 as data_node_protos
@@ -204,3 +206,28 @@ def liquidity_provisions(
             market=market_id, party=party_id
         )
     ).liquidity_provisions
+
+
+def order_subscription(
+    data_client: vac.VegaTradingDataClient,
+    market_id: Optional[str] = None,
+    party_id: Optional[str] = None,
+) -> Iterable[List[vega_protos.vega.Order]]:
+    """Subscribe to a stream of Order updates from the data-node.
+    The stream of orders returned from this function is an iterable which
+    does not end and will continue to tick another order update whenever
+    one is received.
+
+    Args:
+        market_id:
+            Optional[str], If provided, only update orders from this market
+        party_id:
+            Optional[str], If provided, only update orders from this party
+    Returns:
+        Iterable[List[vega.Order]], Infinite iterable of lists of order updates
+    """
+    return data_client.OrdersSubscribe(
+        data_node_protos.trading_data.OrdersSubscribeRequest(
+            market_id=market_id, party_id=party_id
+        )
+    )

--- a/vega_sim/null_service.py
+++ b/vega_sim/null_service.py
@@ -428,11 +428,13 @@ class VegaServiceNull(VegaService):
         transactions_per_block: int = 1,
         seconds_per_block: int = 1,
         use_full_vega_wallet: bool = False,
+        start_order_feed: bool = True,
     ):
         super().__init__(
             can_control_time=True,
             warn_on_raw_data_access=warn_on_raw_data_access,
             seconds_per_block=seconds_per_block,
+            start_order_feed=start_order_feed,
         )
         self.vega_path = vega_path or path.join(vega_bin_path, "vega")
         self.data_node_path = data_node_path or path.join(vega_bin_path, "data-node")
@@ -568,6 +570,7 @@ class VegaServiceNull(VegaService):
         return f"{prefix}localhost:{port}"
 
     def stop(self) -> None:
+        super().stop()
         if self.proc is None:
             logger.info("Stop called but nothing to stop")
         else:

--- a/vega_sim/null_service.py
+++ b/vega_sim/null_service.py
@@ -434,7 +434,6 @@ class VegaServiceNull(VegaService):
             can_control_time=True,
             warn_on_raw_data_access=warn_on_raw_data_access,
             seconds_per_block=seconds_per_block,
-            start_order_feed=start_order_feed,
         )
         self.vega_path = vega_path or path.join(vega_bin_path, "vega")
         self.data_node_path = data_node_path or path.join(vega_bin_path, "data-node")
@@ -453,6 +452,8 @@ class VegaServiceNull(VegaService):
 
         self._wallet = None
         self._use_full_vega_wallet = use_full_vega_wallet
+
+        self._start_order_feed = start_order_feed
 
         if port_config is None:
             self._assign_ports()
@@ -563,6 +564,9 @@ class VegaServiceNull(VegaService):
                 "Vega Running. Console launched at"
                 f" http://localhost:{self.console_port}"
             )
+
+        if self._start_order_feed:
+            self.start_order_monitoring()
 
     # Class internal as at some point the host may vary as well as the port
     @staticmethod

--- a/vega_sim/service.py
+++ b/vega_sim/service.py
@@ -57,7 +57,6 @@ class VegaService(ABC):
         can_control_time: bool = False,
         warn_on_raw_data_access: bool = True,
         seconds_per_block: int = 1,
-        start_order_feed: bool = True,
     ):
         """A generic service for accessing a set of Vega processes.
 
@@ -85,9 +84,6 @@ class VegaService(ABC):
                     service this can be known exactly, for anything else it will be an
                     estimate. Used for waiting/forwarding time and determining how far
                     forwards to place proposals starting/ending.
-            start_order_feed:
-                bool, default True, Whether to start up an order feed which listens to
-                    order updates from the datanode and keeps a local copy of orders
 
         """
         self._core_client = None
@@ -104,9 +100,6 @@ class VegaService(ABC):
         self.order_thread = None
         self.orders_lock = threading.RLock()
         self._order_state_from_feed = {}
-
-        if start_order_feed:
-            self.start_order_monitoring()
 
     @property
     def market_price_decimals(self) -> int:

--- a/vega_sim/service.py
+++ b/vega_sim/service.py
@@ -1,22 +1,25 @@
 from __future__ import annotations
-from collections import defaultdict
 
+import copy
+from email.mime import base
 import logging
-from abc import ABC
-from functools import wraps
+import threading
 import time
-from typing import List, Optional, Tuple, Union
+from abc import ABC
+from collections import defaultdict
+from functools import wraps
+from queue import Queue
+from typing import Dict, List, Optional, Tuple, Union
 
 import grpc
-import vega_sim.grpc.client as vac
-import vega_sim.proto.vega as vega_protos
-
 import vega_sim.api.data as data
 import vega_sim.api.data_raw as data_raw
 import vega_sim.api.faucet as faucet
 import vega_sim.api.governance as gov
 import vega_sim.api.trading as trading
-from vega_sim.api.helpers import num_to_padded_int, forward, wait_for_datanode_sync
+import vega_sim.grpc.client as vac
+import vega_sim.proto.vega as vega_protos
+from vega_sim.api.helpers import forward, num_to_padded_int, wait_for_datanode_sync
 from vega_sim.wallet.base import Wallet
 
 logger = logging.getLogger(__name__)
@@ -54,6 +57,7 @@ class VegaService(ABC):
         can_control_time: bool = False,
         warn_on_raw_data_access: bool = True,
         seconds_per_block: int = 1,
+        start_order_feed: bool = True,
     ):
         """A generic service for accessing a set of Vega processes.
 
@@ -81,6 +85,9 @@ class VegaService(ABC):
                     service this can be known exactly, for anything else it will be an
                     estimate. Used for waiting/forwarding time and determining how far
                     forwards to place proposals starting/ending.
+            start_order_feed:
+                bool, default True, Whether to start up an order feed which listens to
+                    order updates from the datanode and keeps a local copy of orders
 
         """
         self._core_client = None
@@ -93,6 +100,13 @@ class VegaService(ABC):
         self._market_pos_decimals = None
         self._asset_decimals = None
         self.seconds_per_block = seconds_per_block
+
+        self.order_thread = None
+        self.orders_lock = threading.RLock()
+        self._order_state_from_feed = {}
+
+        if start_order_feed:
+            self.start_order_monitoring()
 
     @property
     def market_price_decimals(self) -> int:
@@ -190,6 +204,11 @@ class VegaService(ABC):
 
     def wait_for_datanode_sync(self) -> None:
         wait_for_datanode_sync(self.trading_data_client, self.core_client)
+
+    def stop(self) -> None:
+        if self.order_thread is not None:
+            self.order_queue.put(None)
+            self.order_thread.join()
 
     def login(self, name: str, passphrase: str) -> str:
         """Logs in to existing wallet in the given vega service.
@@ -991,6 +1010,32 @@ class VegaService(ABC):
             position_decimals=self.market_pos_decimals[market_id],
         )
 
+    def order_status_from_feed(
+        self, live_only: bool = True
+    ) -> Dict[str, Dict[str, Dict[str, data.Order]]]:
+        """Returns a copy of current order status based on Order feed if started.
+        If order feed has not been started, dict will be empty
+
+        Args:
+            live_only:
+                bool, default True, whether to filter out dead/cancelled deals
+                    from result
+
+        Returns:
+            Dictionary mapping market ID -> Party ID -> Order ID -> Order detaails"""
+        with self.orders_lock:
+            order_dict = copy.copy(self._order_state_from_feed)
+        if live_only:
+            to_delete = []
+            for market_id, party_orders in order_dict.items():
+                for party_id, orders in party_orders.items():
+                    for order_id, order in orders.items():
+                        if order.status != vega_protos.vega.Order.Status.STATUS_ACTIVE:
+                            to_delete.append((market_id, party_id, order_id))
+            for market_id, party_id, order_id in to_delete:
+                del order_dict[market_id][party_id][order_id]
+        return order_dict
+
     @raw_data
     def liquidity_provisions(
         self,
@@ -1035,3 +1080,49 @@ class VegaService(ABC):
         return self.liquidity_provisions(
             market_id=market_id, party_id=self.wallet.public_key(wallet_name)
         )
+
+    def start_order_monitoring(
+        self,
+        market_id: Optional[str] = None,
+        party_id: Optional[str] = None,
+    ):
+        self.order_queue = data.order_subscription(
+            self.trading_data_client, market_id=market_id, party_id=party_id
+        )
+        base_orders = []
+
+        for m_id in (
+            [market_id] if market_id is not None else [m.id for m in self.all_markets()]
+        ):
+            base_orders.extend(
+                data.all_orders(market_id=m_id, data_client=self.trading_data_client)
+            )
+
+        with self.orders_lock:
+            for order in base_orders:
+                if party_id is not None and order.party_id != party_id:
+                    continue
+                self._order_state_from_feed.setdefault(order.market_id, {}).setdefault(
+                    order.party_id, {}
+                )[order.id] = order
+
+        self.order_thread = threading.Thread(
+            target=self._monitor_stream, args=(self.order_queue,)
+        )
+        self.order_thread.start()
+
+    def _monitor_stream(self, trade_stream: Queue[data.Order]):
+        while True:
+            o = trade_stream.get()
+            if o is None:
+                break
+
+            with self.orders_lock:
+                if o.version > getattr(
+                    self._order_state_from_feed.setdefault(o.market_id, {})
+                    .setdefault(o.party_id, {})
+                    .get(o.id, None),
+                    "version",
+                    0,
+                ):
+                    self._order_state_from_feed[o.market_id][o.party_id][o.id] = o

--- a/vega_sim/wallet/slim_wallet.py
+++ b/vega_sim/wallet/slim_wallet.py
@@ -7,7 +7,6 @@ import numpy as np
 from nacl.encoding import HexEncoder
 from nacl.signing import SigningKey
 from typing import Optional
-from vega_sim.api.trading import submit_order
 from vega_sim.grpc.client import VegaCoreClient
 from vega_sim.wallet.base import Wallet
 


### PR DESCRIPTION
### Description

Adding the functionality to allow the service to listen to Order events and then maintain an up-to-date view of all orders on the market.

Requires some handling around threading as we're reading/writing to the same object, however the locking should be largely covering this.

Tests added to ensure working functionality