### PR TITLE
fix: Clone random states to properly replicate in parameter tests

### DIFF
--- a/vega_sim/parameter_test/parameter/experiment.py
+++ b/vega_sim/parameter_test/parameter/experiment.py
@@ -1,14 +1,14 @@
+import copy
 import csv
-from dataclasses import dataclass
 import json
 import os
-from typing import Any, Dict, List, Optional, Tuple
 import pathlib
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple
+
 import numpy as np
-
-from vega_sim.scenario.scenario import Scenario
 from vega_sim.null_service import VegaServiceNull
-
+from vega_sim.scenario.scenario import Scenario
 
 PARAMETER_AMEND_WALLET = ("param", "amend")
 
@@ -89,7 +89,7 @@ def run_single_parameter_experiment(
     ]
     for value in experiment.values:
         results[value] = []
-        for state in random_seeds:
+        for state in copy.deepcopy(random_seeds):
             results[value].append(
                 _run_parameter_iteration(
                     scenario=experiment.scenario,


### PR DESCRIPTION
### Description

A minor fix to properly clone random states which we use to ensure the same price series/action series process is used by agents across runs where possible.

The issue was that we were reusing the *exact* random state object, which obviously just continued producing numbers from where the previous one left off. Instead we use a cloned version so that each will start fresh.