### PR TITLE
test: Try not waiting for auction limit order to stop intermittent test breakages

### DIFF
--- a/vega_sim/scenario/common/agents.py
+++ b/vega_sim/scenario/common/agents.py
@@ -626,6 +626,7 @@ class OpenAuctionPass(StateAgentWithWallet):
             side=self.side,
             volume=self.opening_auction_trade_amount,
             price=self.initial_price,
+            wait=False,
         )
 
     def step(self, vega_state: VegaState):
@@ -908,7 +909,6 @@ class LimitOrderTrader(StateAgentWithWallet):
                 self._cancel_order(vega_state=vega_state)
 
     def _submit_order(self, vega_state: VegaState):
-
         # Calculate reference_buy_price and reference_sell_price of price distribution
         if (self.spread is None) or (self.price_process is None):
             # If agent does not have price_process data, offset orders from best bid/ask
@@ -1102,7 +1102,6 @@ class LiquidityProvider(StateAgentWithWallet):
         self.commitment_amount = commitment_amount
 
     def initialise(self, vega: VegaServiceNull):
-
         super().initialise(vega=vega)
 
         self.market_id = [


### PR DESCRIPTION
### Description
<!---
What is the change?
--->
Market Sim is failing intermittently when waiting for this order to submit on Jenkins. This should be a safe non-failing order that we don't need the ID back for so try skipping the waiting and see if this resolves.

### Testing
<!---
How has the change been tested? Were new unit/integration tests added and do current ones cover?
--->
No additional tests needed. Change covered by existing integration

### Breaking Changes
<!---
Are any of the changes in this PR breaking/requiring of a change in workflow?
--->
None

### Closes
<!---
Does this close any issues?
--->
None
