### PR TITLE
test: Experiment with removing excessive time forwarding

### DIFF
--- a/vega_sim/api/governance.py
+++ b/vega_sim/api/governance.py
@@ -409,10 +409,10 @@ def _make_and_wait_for_proposal(
     )
     logger.debug("Waiting for proposal acceptance")
 
+    time_forward_fn()
     proposal = wait_for_acceptance(
         proposal.reference,
         lambda p: _proposal_loader(p, data_client),
-        time_forward_fn=time_forward_fn,
     )
 
     prop_state = enum_to_str(

--- a/vega_sim/api/helpers.py
+++ b/vega_sim/api/helpers.py
@@ -105,7 +105,6 @@ def wait_for_core_catchup(
 def wait_for_acceptance(
     submission_ref: str,
     submission_load_func: Callable[[str], T],
-    time_forward_fn: Optional[Callable[[None], None]] = None,
 ) -> T:
     logger.debug("Waiting for proposal acceptance")
     submission_accepted = False
@@ -113,8 +112,6 @@ def wait_for_acceptance(
         try:
             proposal = submission_load_func(submission_ref)
         except:
-            if time_forward_fn is not None:
-                time_forward_fn()
             time.sleep(0.001)
             continue
 
@@ -122,8 +119,6 @@ def wait_for_acceptance(
             logger.debug("Your proposal has been accepted by the network")
             submission_accepted = True
             break
-        if time_forward_fn is not None:
-            time_forward_fn()
         time.sleep(0.001)
 
     if not submission_accepted:

--- a/vega_sim/api/trading.py
+++ b/vega_sim/api/trading.py
@@ -129,16 +129,12 @@ def submit_order(
             )
             return data_client.OrderByReference(order_ref_request).order
 
+        time_forward_fn()
         # Wait for proposal to be included in a block and to be accepted by Vega network
         logger.debug("Waiting for proposal acceptance")
         response = wait_for_acceptance(
             order_ref,
             _proposal_loader,
-            time_forward_fn=(
-                time_forward_fn
-                if time_forward_fn is not None
-                else lambda: time.sleep(1)
-            ),
         )
         order_status = enum_to_str(vega_protos.vega.Order.Status, response.status)
 


### PR DESCRIPTION
### Description
<!---
What is the change?
--->
Remove forwarding time whilst waiting for proposals to pass. Just do the once. This should make proposals always visible when combines with the physical waits, but will need keeping an eye on.

### Testing
<!---
How has the change been tested? Were new unit/integration tests added and do current ones cover?
--->
Tests pass

### Breaking Changes
<!---
Are any of the changes in this PR breaking/requiring of a change in workflow?
--->
None

### Closes
<!---
Does this close any issues?
--->
None
