### PR TITLE
feat: Allow specification of market maker's bid/ask volumes

### DIFF
--- a/vega_sim/scenario/ideal_market_maker_v2/agents.py
+++ b/vega_sim/scenario/ideal_market_maker_v2/agents.py
@@ -45,6 +45,7 @@ class OptimalMarketMaker(StateAgentWithWallet):
         initial_asset_mint: float = 1000000,
         spread: float = 0.002,
         num_steps: int = 180,
+        limit_order_size: float = 10,
         market_order_arrival_rate: float = 5,
         kappa: float = 500,
         inventory_upper_boundary: int = 20,
@@ -70,6 +71,7 @@ class OptimalMarketMaker(StateAgentWithWallet):
         self.time = num_steps
         self.Lambda = market_order_arrival_rate
         self.kappa = kappa
+        self.limit_order_size = limit_order_size
         self.q_upper = inventory_upper_boundary
         self.q_lower = inventory_lower_boundary
         self.alpha = terminal_penalty_parameter
@@ -264,7 +266,7 @@ class OptimalMarketMaker(StateAgentWithWallet):
         self._place_orders(
             buy_offset=self.bid_depth - self.spread / 2,
             sell_offset=self.ask_depth - self.spread / 2,
-            volume=10,
+            volume=self.limit_order_size,
             buy_order=buy_order,
             sell_order=sell_order,
         )

--- a/vega_sim/scenario/ideal_market_maker_v2/scenario.py
+++ b/vega_sim/scenario/ideal_market_maker_v2/scenario.py
@@ -44,6 +44,7 @@ class IdealMarketMaker(Scenario):
         q_lower: int = -20,
         alpha: float = 10**-4,
         phi: float = 5 * 10**-6,
+        market_marker_limit_order_size: float = 10,
         lp_commitamount: float = 200000,
         spread: int = 2,
         block_size: int = 1,
@@ -87,6 +88,7 @@ class IdealMarketMaker(Scenario):
         self.lp_commitamount = lp_commitamount
         self.initial_asset_mint = initial_asset_mint
         self.backgroundmarket_tick_spacing = backgroundmarket_tick_spacing
+        self.market_marker_limit_order_size = market_marker_limit_order_size
         self.backgroundmarket_number_levels_per_side = (
             backgroundmarket_number_levels_per_side
         )
@@ -138,6 +140,7 @@ class IdealMarketMaker(Scenario):
             num_steps=self.num_steps,
             market_order_arrival_rate=self.buy_intensity,
             kappa=self.kappa,
+            limit_order_size=self.market_marker_limit_order_size,
             inventory_upper_boundary=self.q_upper,
             inventory_lower_boundary=self.q_lower,
             terminal_penalty_parameter=self.alpha,


### PR DESCRIPTION
### Description
<!---
What is the change?
--->
Adding the ability to specify an Ideal Market Maker's volume at which they post limit orders

### Testing
<!---
How has the change been tested? Were new unit/integration tests added and do current ones cover?
--->
Tests pass

### Breaking Changes
<!---
Are any of the changes in this PR breaking/requiring of a change in workflow?
--->
None


### Closes
<!---
Does this close any issues?
--->
None