### PR TITLE
fix: vega_wallet login method

### DIFF
--- a/tests/vega_sim/test_service.py
+++ b/tests/vega_sim/test_service.py
@@ -74,11 +74,8 @@ def test_base_service_wallet_login(stub_service: StubService):
         )
         req_mocker.get(
             WALLET_KEY_URL.format(wallet_server_url="localhost:TEST_WALLET"),
-            json=lambda req, _: {"keys": 'TEST_PHRASE[{"name": "default_key"}]'},
+            json=lambda req, _: {"keys": [{"pub": "TEST_NAME"}]},
         )
         stub_service.login("TEST_NAME", "TEST_PHRASE")
         assert stub_service.wallet.login_tokens["TEST_NAME"] == "TEST_NAMETEST_PHRASE"
-        assert (
-            stub_service.wallet.pub_keys["TEST_NAME"]
-            == 'TEST_PHRASE[{"name": "default_key"}]'
-        )
+        assert stub_service.wallet.pub_keys["TEST_NAME"] == "TEST_NAME"

--- a/vega_sim/wallet/vega_wallet.py
+++ b/vega_sim/wallet/vega_wallet.py
@@ -81,7 +81,7 @@ class VegaWallet(Wallet):
         )
         response.raise_for_status()
         self.login_tokens[name] = response.json()["token"]
-        self.pub_keys[name] = self.get_keypairs(name)
+        self.pub_keys[name] = self.get_keypairs(name)[0]["pub"]
         return self.login_tokens[name]
 
     def generate_keypair(


### PR DESCRIPTION
### Description
Small change to the `login` method of the `vega_wallet` class.

Change required to ensure method correctly initialises the `pub_keys` attribute in the same format as the `create_wallet` method and the same format expected by the `submit_transaction` method.

### Testing
Initially `test_base_service_wallet_login` in `test_service.py` failing. Response from requests mocker updated to reflect changes. Now passing tests.

### Breaking Changes
Hopefully none.

### Closes
#149 