### PR TITLE
fix: SlimWallet default key name

### DIFF
--- a/vega_sim/wallet/slim_wallet.py
+++ b/vega_sim/wallet/slim_wallet.py
@@ -134,7 +134,9 @@ class SlimWallet(Wallet):
                 name=name,
                 passphrase=kwargs.get("passphrase", self.full_wallet_default_pass),
             )
-            self.pub_keys[name] = {self.vega_default_key_name: self.vega_wallet.public_key(name)}
+            self.pub_keys[name] = {
+                self.vega_default_key_name: self.vega_wallet.public_key(name)
+            }
 
     def login(self, name: str, **kwargs) -> None:
         """Logs in to existing wallet in the given vega service.

--- a/vega_sim/wallet/slim_wallet.py
+++ b/vega_sim/wallet/slim_wallet.py
@@ -134,7 +134,7 @@ class SlimWallet(Wallet):
                 name=name,
                 passphrase=kwargs.get("passphrase", self.full_wallet_default_pass),
             )
-            self.pub_keys[name] = {"key_name": self.vega_wallet.public_key(name)}
+            self.pub_keys[name] = {self.vega_default_key_name: self.vega_wallet.public_key(name)}
 
     def login(self, name: str, **kwargs) -> None:
         """Logs in to existing wallet in the given vega service.


### PR DESCRIPTION
### Description
One-liner change to fix default key name in the SlimWallet which was causing example run with following command to fail.

`python -m examples.nullchain`

### Testing
Passing all tests and examples.
