### PR TITLE
feat: Adding smarter liquidity provision to Shaped LP

### DIFF
--- a/vega_sim/parameter_test/parameter/configs.py
+++ b/vega_sim/parameter_test/parameter/configs.py
@@ -249,7 +249,7 @@ TAU_SCALING_FACTOR_IDEAL_CURVE = SingleParameterExperiment(
             ]
         ),
     ),
-    runs_per_scenario=1,
+    runs_per_scenario=2,
     additional_parameters_to_set=[
         ("market.liquidity.targetstake.triggering.ratio", "1")
     ],


### PR DESCRIPTION
### Description
<!---
What is the change?
--->
Making the Shaped LP's provisions slightly smarter by posting liquidity just beyond the current shape

### Testing
<!---
How has the change been tested? Were new unit/integration tests added and do current ones cover?
--->
Manually test and ensured prices moved as expected


### Breaking Changes
<!---
Are any of the changes in this PR breaking/requiring of a change in workflow?
--->

### Closes
<!---
Does this close any issues?
--->
