### PR TITLE
fix: correct PriceSensitiveMarketOrder agent logic

### DIFF
--- a/vega_sim/scenario/common/agents.py
+++ b/vega_sim/scenario/common/agents.py
@@ -239,10 +239,10 @@ class PriceSensitiveMarketOrderTrader(StateAgentWithWallet):
         best_bid, best_ask = self.vega.best_prices(self.market_id)
 
         will_buy = self.random_state.rand() < np.exp(
-            -1 * self.probability_decay * abs(best_bid - self.curr_price)
+            -1 * self.probability_decay * abs(best_ask - self.curr_price)
         )
         will_sell = self.random_state.rand() < np.exp(
-            -1 * self.probability_decay * abs(best_ask - self.curr_price)
+            -1 * self.probability_decay * abs(best_bid - self.curr_price)
         )
 
         if buy_first and will_buy:

--- a/vega_sim/scenario/common/agents.py
+++ b/vega_sim/scenario/common/agents.py
@@ -239,10 +239,10 @@ class PriceSensitiveMarketOrderTrader(StateAgentWithWallet):
         best_bid, best_ask = self.vega.best_prices(self.market_id)
 
         will_buy = self.random_state.rand() < np.exp(
-            -1 * self.probability_decay * abs(best_ask - self.curr_price)
+            -1 * self.probability_decay * max([best_ask - self.curr_price, 0])
         )
         will_sell = self.random_state.rand() < np.exp(
-            -1 * self.probability_decay * abs(best_bid - self.curr_price)
+            -1 * self.probability_decay * max([self.curr_price - best_bid, 0])
         )
 
         if buy_first and will_buy:


### PR DESCRIPTION
### Description

Fix to how the `PriceSensitiveMarketOrder` agent determines whether to buy or sell.

- Change stops `ExponentialShapedMarketMaker` position diverging from zero
- Change stops `PriceSensitiveMarketOrder` agent not placing orders when offset is negative (i.e. arbitrage opportunity)

### Testing
Passing all tests.

### Breaking Changes
None.
