### PR TITLE
fix: correct args in adhoc

### DIFF
--- a/vega_sim/scenario/adhoc.py
+++ b/vega_sim/scenario/adhoc.py
@@ -51,16 +51,19 @@ def main():
             store_transactions=args.store,
         ) as vega:
             scenario.run_iteration(
-                vega=vega, network=Network[args.network], pause_at_completion=args.pause
+                vega=vega,
+                network=Network[args.network],
+                pause_at_completion=args.pause,
             )
     else:
         with VegaServiceNetwork(
-            network=Network[args.network],
+            network=Network[args.network].value,
             automatic_consent=True,
             no_version_check=True,
         ) as vega:
             scenario.run_iteration(
-                vega=vega, network=Network[args.network], pause_at_completion=args.pause
+                vega=vega,
+                network=Network[args.network],
             )
 
 


### PR DESCRIPTION
### Description
Small fix changing arguments to `VegaServiceNetwork` and `run_iteration` in the scenario runner `adhoc.py`

### Testing
Passing all tests.
