### PR TITLE
feat: add list_orders method to service

### DIFF
--- a/vega_sim/api/data_raw.py
+++ b/vega_sim/api/data_raw.py
@@ -162,6 +162,40 @@ def infrastructure_fee_accounts(
     ).accounts
 
 
+def list_orders(
+    data_client: vac.VegaTradingDataClientV2,
+    market_id: str,
+    party_id: str,
+    live_only: bool = True,
+) -> List[vega_protos.vega.Orders]:
+    """Gets a list of Orders for the specified market and party.
+
+    Function queries the datanode for a response of orders for the specified market_id
+    and party_id and state (defaults to live orders only). The function then unrolls
+    pagination and returns a list of Orders.
+
+    Args:
+        data_client (vac.VegaTradingDataClientV2):
+            An instantiated gRPC trading_data_client_V2.
+        market_id (str):
+            Id for market to return orders from.
+        party_id (str):
+            Id for party to return orders from.
+        live_only (bool, optional):
+            Whether to only return live orders. Defaults to True.
+
+    Returns:
+        _type_: _description_
+    """
+    return unroll_v2_pagination(
+        base_request=data_node_protos_v2.trading_data.ListOrdersRequest(
+            market_id=market_id, party_id=party_id, live_only=live_only
+        ),
+        request_func=lambda x: data_client.ListOrders(x).orders,
+        extraction_func=lambda res: [i.node for i in res.edges],
+    )
+
+
 def order_status(
     order_id: str, data_client: vac.VegaTradingDataClient, version: int = 0
 ) -> Optional[vega_protos.vega.Order]:

--- a/vega_sim/scenario/common/agents.py
+++ b/vega_sim/scenario/common/agents.py
@@ -239,10 +239,10 @@ class PriceSensitiveMarketOrderTrader(StateAgentWithWallet):
         best_bid, best_ask = self.vega.best_prices(self.market_id)
 
         will_buy = self.random_state.rand() < np.exp(
-            -1 * self.probability_decay * abs(best_bid - self.curr_price)
+            -1 * self.probability_decay * abs(best_ask - self.curr_price)
         )
         will_sell = self.random_state.rand() < np.exp(
-            -1 * self.probability_decay * abs(best_ask - self.curr_price)
+            -1 * self.probability_decay * abs(best_bid - self.curr_price)
         )
 
         if buy_first and will_buy:

--- a/vega_sim/scenario/common/agents.py
+++ b/vega_sim/scenario/common/agents.py
@@ -239,10 +239,10 @@ class PriceSensitiveMarketOrderTrader(StateAgentWithWallet):
         best_bid, best_ask = self.vega.best_prices(self.market_id)
 
         will_buy = self.random_state.rand() < np.exp(
-            -1 * self.probability_decay * abs(best_ask - self.curr_price)
+            -1 * self.probability_decay * max([best_ask - self.curr_price, 0])
         )
         will_sell = self.random_state.rand() < np.exp(
-            -1 * self.probability_decay * abs(best_bid - self.curr_price)
+            -1 * self.probability_decay * max([self.curr_price - best_bid, 0])
         )
 
         if buy_first and will_buy:

--- a/vega_sim/scenario/fairground/scenario.py
+++ b/vega_sim/scenario/fairground/scenario.py
@@ -299,6 +299,7 @@ class Fairground(Scenario):
             inventory_upper_boundary=self.market_maker_args["inventory_upper_boundary"],
             num_steps=self.n_steps,
             price_process_generator=iter(self.price_process),
+            orders_from_stream=False,
         )
 
         # Setup agents for passing opening auction

--- a/vega_sim/service.py
+++ b/vega_sim/service.py
@@ -1416,6 +1416,37 @@ class VegaService(ABC):
             market_id=market_id,
         )
 
+    def list_orders(
+        self,
+        wallet_name: str,
+        key_name: str,
+        market_id: str,
+        live_only: Optional[bool] = True,
+    ) -> List[data.Order]:
+        """Return a list of orders for the specified market and party.
+
+        Args:
+            wallet_name (str):
+            Name of wallet to return orders for.
+            key_name (str):
+            Name of key to return orders for.
+            market_id:
+                Id of market to return orders from.
+            live_only (Optional[bool], optional):
+                Whether to return only live orders. Defaults to True.
+
+        Returns:
+            List[data.Order]:
+                List of orders for the specified market and party.
+        """
+        return data.list_orders(
+            data_client=self.trading_data_client,
+            data_client_v2=self.trading_data_client_v2,
+            market_id=market_id,
+            party_id=self.wallet.public_key(name=wallet_name, key_name=key_name),
+            live_only=live_only,
+        )
+
     def get_trades(
         self,
         market_id: str,


### PR DESCRIPTION
### Description
Market-makers need to be able to get a list of active order ids for their public key and market id.

Issues were countered using `start_order_monitoring` when running on a an existing Vega network and the `all_orders` method was too slow. A new method has been added to the VegaService which allows a trader to get a list of all orders for a specified party and market and filter out any orders that are not live.

This allows market-makers to be run on a network. Long term, order stream issues should be looked into and resolved.

### Testing
Passing all tests. For an example run:

`python -m vega_sim.scenario.adhoc -s fairground --network NULLCHAIN  --console --pause --debug
`
