### PR TITLE
feat: flexible market id finder

### DIFF
--- a/examples/agent_market/agents.py
+++ b/examples/agent_market/agents.py
@@ -159,7 +159,7 @@ class MarketMaker(StateAgentWithWallet):
             termination_wallet=self.terminate_wallet_name,
             liquidity_commitment=liquidity_commitment,
         )
-        self.vega.forward("2s")
+        self.vega.wait_for_total_catchup()
 
         self.market_id = self.vega.all_markets()[0].id
 

--- a/vega_sim/reinforcement/agents/simple_agent.py
+++ b/vega_sim/reinforcement/agents/simple_agent.py
@@ -126,11 +126,8 @@ class SimpleAgent(AgentWithWallet):
         super().initialise(vega=vega, create_wallet=True)
 
         # Get market id
-        self.market_id = [
-            m.id
-            for m in self.vega.all_markets()
-            if m.tradable_instrument.instrument.name == self.market_name
-        ][0]
+        self.market_id = self.vega.find_market_id(name=self.market_name)
+
         # Get asset id
         self.asset_id = self.vega.find_asset_id(symbol=self.asset_name)
         # Top up asset

--- a/vega_sim/scenario/common/agents.py
+++ b/vega_sim/scenario/common/agents.py
@@ -105,11 +105,7 @@ class MarketOrderTrader(StateAgentWithWallet):
         # Initialise wallet
         super().initialise(vega=vega, create_wallet=create_wallet)
         # Get market id
-        self.market_id = [
-            m.id
-            for m in self.vega.all_markets()
-            if m.tradable_instrument.instrument.name == self.market_name
-        ][0]
+        self.market_id = self.vega.find_market_id(name=self.market_name)
 
         # Get asset id
         self.asset_id = self.vega.find_asset_id(symbol=self.asset_name)
@@ -216,11 +212,7 @@ class PriceSensitiveMarketOrderTrader(StateAgentWithWallet):
         # Initialise wallet
         super().initialise(vega=vega, create_wallet=create_wallet)
         # Get market id
-        self.market_id = [
-            m.id
-            for m in self.vega.all_markets()
-            if m.tradable_instrument.instrument.name == self.market_name
-        ][0]
+        self.market_id = self.vega.find_market_id(name=self.market_name)
 
         # Get asset id
         self.asset_id = self.vega.find_asset_id(symbol=self.asset_name)
@@ -335,11 +327,7 @@ class BackgroundMarket(StateAgentWithWallet):
         # Initialise wallet
         super().initialise(vega=vega, create_wallet=create_wallet)
         # Get market id
-        self.market_id = [
-            m.id
-            for m in self.vega.all_markets()
-            if m.tradable_instrument.instrument.name == self.market_name
-        ][0]
+        self.market_id = self.vega.find_market_id(name=self.market_name)
 
         # Get asset id
         asset_id = self.vega.find_asset_id(symbol=self.asset_name)
@@ -572,11 +560,7 @@ class MultiRegimeBackgroundMarket(StateAgentWithWallet):
         # Initialise wallet
         super().initialise(vega=vega, create_wallet=create_wallet)
         # Get market id
-        self.market_id = [
-            m.id
-            for m in self.vega.all_markets()
-            if m.tradable_instrument.instrument.name == self.market_name
-        ][0]
+        self.market_id = self.vega.find_market_id(name=self.market_name)
 
         # Get asset id
         asset_id = self.vega.find_asset_id(symbol=self.asset_name)
@@ -778,11 +762,7 @@ class OpenAuctionPass(StateAgentWithWallet):
         # Initialise wallet
         super().initialise(vega=vega, create_wallet=create_wallet)
         # Get market id
-        self.market_id = [
-            m.id
-            for m in self.vega.all_markets()
-            if m.tradable_instrument.instrument.name == self.market_name
-        ][0]
+        self.market_id = self.vega.find_market_id(name=self.market_name)
 
         self.vega.wait_for_total_catchup()
         # Get asset id
@@ -935,11 +915,7 @@ class MarketManager(StateAgentWithWallet):
         self.vega.wait_fn(5)
 
         # Get market id
-        self.market_id = [
-            m.id
-            for m in self.vega.all_markets()
-            if m.tradable_instrument.instrument.name == self.market_name
-        ][0]
+        self.market_id = self.vega.find_market_id(name=self.market_name)
         if self.commitment_amount:
             self.vega.submit_liquidity(
                 wallet_name=self.wallet_name,
@@ -1044,11 +1020,7 @@ class ShapedMarketMaker(StateAgentWithWallet):
             self.vega.wait_for_total_catchup()
 
         # Get market id
-        self.market_id = [
-            m.id
-            for m in self.vega.all_markets()
-            if m.tradable_instrument.instrument.name == self.market_name
-        ][0]
+        self.market_id = self.vega.find_market_id(name=self.market_name)
 
         if (
             initial_liq := self.liquidity_commitment_fn(None)
@@ -1531,11 +1503,7 @@ class LimitOrderTrader(StateAgentWithWallet):
         """
 
         super().initialise(vega=vega, create_wallet=create_wallet)
-        self.market_id = [
-            m.id
-            for m in self.vega.all_markets()
-            if m.tradable_instrument.instrument.name == self.market_name
-        ][0]
+        self.market_id = self.vega.find_market_id(name=self.market_name)
 
         self.asset_id = self.vega.find_asset_id(symbol=self.asset_name)
         if mint_wallet:
@@ -1668,11 +1636,7 @@ class InformedTrader(StateAgentWithWallet):
         super().initialise(vega=vega, create_wallet=create_wallet)
 
         # Get market id
-        self.market_id = [
-            m.id
-            for m in self.vega.all_markets()
-            if m.tradable_instrument.instrument.name == self.market_name
-        ][0]
+        self.market_id = self.vega.find_market_id(name=self.market_name)
 
         # Get asset id
         tDAI_id = self.vega.find_asset_id(symbol=self.asset_name)
@@ -1781,11 +1745,7 @@ class LiquidityProvider(StateAgentWithWallet):
     ):
         super().initialise(vega=vega, create_wallet=create_wallet)
 
-        self.market_id = [
-            m.id
-            for m in self.vega.all_markets()
-            if m.tradable_instrument.instrument.name == self.market_name
-        ][0]
+        self.market_id = self.vega.find_market_id(name=self.market_name)
         self.asset_id = self.vega.find_asset_id(symbol=self.asset_name)
         if mint_wallet:
             self.vega.mint(
@@ -1884,11 +1844,7 @@ class MomentumTrader(StateAgentWithWallet):
     ):
         super().initialise(vega=vega, create_wallet=create_wallet)
 
-        self.market_id = [
-            m.id
-            for m in self.vega.all_markets()
-            if m.tradable_instrument.instrument.name == self.market_name
-        ][0]
+        self.market_id = self.vega.find_market_id(name=self.market_name)
 
         self.asset_id = self.vega.find_asset_id(symbol=self.asset_name)
         if mint_wallet:

--- a/vega_sim/scenario/common/agents.py
+++ b/vega_sim/scenario/common/agents.py
@@ -912,7 +912,7 @@ class MarketManager(StateAgentWithWallet):
             key_name=self.key_name,
             termination_key=self.terminate_key_name,
         )
-        self.vega.wait_fn(5)
+        self.vega.wait_for_total_catchup()
 
         # Get market id
         self.market_id = self.vega.find_market_id(name=self.market_name)

--- a/vega_sim/scenario/ideal_market_maker/agents.py
+++ b/vega_sim/scenario/ideal_market_maker/agents.py
@@ -171,11 +171,7 @@ class OptimalMarketMaker(StateAgentWithWallet):
         self.vega.wait_fn(5)
 
         # Get market id
-        self.market_id = [
-            m.id
-            for m in self.vega.all_markets()
-            if m.tradable_instrument.instrument.name == self.market_name
-        ][0]
+        self.market_id = self.vega.find_market_id(name=self.market_name)
 
         vega.submit_liquidity(
             wallet_name=self.wallet_name,
@@ -332,11 +328,7 @@ class MarketOrderTrader(StateAgentWithWallet):
         super().initialise(vega=vega)
 
         # Get market id
-        self.market_id = [
-            m.id
-            for m in self.vega.all_markets()
-            if m.tradable_instrument.instrument.name == self.market_name
-        ][0]
+        self.market_id = self.vega.find_market_id(name=self.market_name)
 
         # Get asset id
         tDAI_id = self.vega.find_asset_id(symbol=self.asset_name)
@@ -406,11 +398,7 @@ class LimitOrderTrader(StateAgentWithWallet):
         # Initialise wallet
         super().initialise(vega=vega)
         # Get market id
-        self.market_id = [
-            m.id
-            for m in self.vega.all_markets()
-            if m.tradable_instrument.instrument.name == self.market_name
-        ][0]
+        self.market_id = self.vega.find_market_id(name=self.market_name)
 
         # Get asset id
         tDAI_id = self.vega.find_asset_id(symbol=self.asset_name)
@@ -568,11 +556,7 @@ class OpenAuctionPass(StateAgentWithWallet):
         # Initialise wallet
         super().initialise(vega=vega)
         # Get market id
-        self.market_id = [
-            m.id
-            for m in self.vega.all_markets()
-            if m.tradable_instrument.instrument.name == self.market_name
-        ][0]
+        self.market_id = self.vega.find_market_id(name=self.market_name)
 
         # Get asset id
         tDAI_id = self.vega.find_asset_id(symbol=self.asset_name)
@@ -641,11 +625,7 @@ class OptimalLiquidityProvider(StateAgentWithWallet):
         super().initialise(vega=vega)
 
         # Get market id
-        self.market_id = [
-            m.id
-            for m in self.vega.all_markets()
-            if m.tradable_instrument.instrument.name == self.market_name
-        ][0]
+        self.market_id = self.vega.find_market_id(name=self.market_name)
 
         # Get asset id
         tDAI_id = self.vega.find_asset_id(symbol=self.asset_name)
@@ -797,11 +777,7 @@ class InformedTrader(StateAgentWithWallet):
         super().initialise(vega=vega)
 
         # Get market id
-        self.market_id = [
-            m.id
-            for m in self.vega.all_markets()
-            if m.tradable_instrument.instrument.name == self.market_name
-        ][0]
+        self.market_id = self.vega.find_market_id(name=self.market_name)
 
         # Get asset id
         tDAI_id = self.vega.find_asset_id(symbol=self.asset_name)

--- a/vega_sim/scenario/ideal_market_maker/agents.py
+++ b/vega_sim/scenario/ideal_market_maker/agents.py
@@ -168,7 +168,7 @@ class OptimalMarketMaker(StateAgentWithWallet):
             position_decimals=self.market_position_decimal,
             future_asset=self.asset_name,
         )
-        self.vega.wait_fn(5)
+        self.vega.wait_for_total_catchup()
 
         # Get market id
         self.market_id = self.vega.find_market_id(name=self.market_name)

--- a/vega_sim/scenario/ideal_market_maker_v2/agents.py
+++ b/vega_sim/scenario/ideal_market_maker_v2/agents.py
@@ -194,11 +194,8 @@ class OptimalMarketMaker(StateAgentWithWallet):
             self.vega.wait_fn(5)
 
         # Get market id
-        self.market_id = [
-            m.id
-            for m in self.vega.all_markets()
-            if m.tradable_instrument.instrument.name == self.market_name
-        ][0]
+        self.market_id = self.vega.find_market_id(name=self.market_name)
+
         vega.submit_liquidity(
             wallet_name=self.wallet_name,
             market_id=self.market_id,

--- a/vega_sim/scenario/ideal_market_maker_v2/agents.py
+++ b/vega_sim/scenario/ideal_market_maker_v2/agents.py
@@ -191,7 +191,7 @@ class OptimalMarketMaker(StateAgentWithWallet):
                 position_decimals=self.market_position_decimal,
                 future_asset=self.asset_name,
             )
-            self.vega.wait_fn(5)
+            self.vega.wait_for_total_catchup()
 
         # Get market id
         self.market_id = self.vega.find_market_id(name=self.market_name)

--- a/vega_sim/service.py
+++ b/vega_sim/service.py
@@ -1206,6 +1206,25 @@ class VegaService(ABC):
             key_name=key_name,
         )
 
+    def find_market_id(self, name: str, raise_on_missing: bool = False) -> str:
+        """Looks up the Market ID of a given market name
+
+        Args:
+            name:
+                str, the name of the market to look for
+            raise_on_missing:
+                bool, whether to raise an Error or silently return if the market does
+                not exist
+
+        Returns:
+            str, the ID of the market
+        """
+        return data.find_market_id(
+            name=name,
+            raise_on_missing=raise_on_missing,
+            data_client=self.trading_data_client,
+        )
+
     def find_asset_id(self, symbol: str, raise_on_missing: bool = False) -> str:
         """Looks up the Asset ID of a given asset name
 


### PR DESCRIPTION
### Description
Adds a `find_market_id` method to the vega `Service` class and updates all agents to use it.

Method returns the market id of the market matching the specified market name providing it is in one of the following states:

- `STATE_PENDING`
- `STATE_ACTIVE`
- `STATE_SUSPENDED`

If more than one market with a matching market name is found the method returns the id of the market with the most recently pending timestamp.

PR required to run market-sim bots on networks. Further matching criteria can be added in the future to further improve method.

### Testing
Passing all tests locally.

### Closes
Closes #212 
