### PR TITLE
feat: update liquidity offset calculations

### DIFF
--- a/vega_sim/scenario/common/agents.py
+++ b/vega_sim/scenario/common/agents.py
@@ -1274,12 +1274,17 @@ class ExponentialShapedMarketMaker(ShapedMarketMaker):
         buy_specs = [["PEGGED_REFERENCE_BEST_BID", 5, 1]]
         sell_specs = [["PEGGED_REFERENCE_BEST_ASK", 5, 1]]
 
+        if (self.curr_asks is not None) and (self.curr_bids is not None):
+            est_mid_price = (self.curr_bids[0].price + self.curr_asks[0].price) * 0.5
+        elif state is not None:
+            est_mid_price = state.market_state[self.market_id].midprice
+
         if self.curr_asks is not None:
             next_ask_step = self.curr_asks[-1].price + self.tick_spacing
             sell_specs = [
                 [
                     "PEGGED_REFERENCE_MID",
-                    next_ask_step - state.market_state[self.market_id].midprice,
+                    next_ask_step - est_mid_price,
                     1,
                 ]
             ]
@@ -1288,7 +1293,7 @@ class ExponentialShapedMarketMaker(ShapedMarketMaker):
             buy_specs = [
                 [
                     "PEGGED_REFERENCE_MID",
-                    state.market_state[self.market_id].midprice - next_bid_step,
+                    est_mid_price - next_bid_step,
                     1,
                 ]
             ]

--- a/vega_sim/scenario/common/agents.py
+++ b/vega_sim/scenario/common/agents.py
@@ -1271,13 +1271,14 @@ class ExponentialShapedMarketMaker(ShapedMarketMaker):
             )
 
     def _liq_provis(self, state: VegaState) -> LiquidityProvision:
-        buy_specs = [["PEGGED_REFERENCE_BEST_BID", 5, 1]]
-        sell_specs = [["PEGGED_REFERENCE_BEST_ASK", 5, 1]]
 
         if (self.curr_asks is not None) and (self.curr_bids is not None):
             est_mid_price = (self.curr_bids[0].price + self.curr_asks[0].price) * 0.5
         elif state is not None:
             est_mid_price = state.market_state[self.market_id].midprice
+        else:
+            buy_specs = [["PEGGED_REFERENCE_BEST_BID", 5, 1]]
+            sell_specs = [["PEGGED_REFERENCE_BEST_ASK", 5, 1]]
 
         if self.curr_asks is not None:
             next_ask_step = self.curr_asks[-1].price + self.tick_spacing

--- a/vega_sim/scenario/common/agents.py
+++ b/vega_sim/scenario/common/agents.py
@@ -1277,6 +1277,7 @@ class ExponentialShapedMarketMaker(ShapedMarketMaker):
         elif state is not None:
             est_mid_price = state.market_state[self.market_id].midprice
         else:
+            est_mid_price = None
             buy_specs = [["PEGGED_REFERENCE_BEST_BID", 5, 1]]
             sell_specs = [["PEGGED_REFERENCE_BEST_ASK", 5, 1]]
 


### PR DESCRIPTION
### Description
Updates the `ExponentialShapedMarketMaker` to calculate it's liquidity offsets from an estimated mid-price rather than the outdated mid-price from before order amendments (current implementation).

The agent has to calculate an estimate to avoid putting calls to `wait_for_datanode_sync` and data-node queries inside agent `step` methods.

The estimated mid-price is calculated from the average of the MM's best-bid and best-ask and therefore assumes the MM is providing the market best-bid and market-best ask (valid assumption for most market-sim cases). The agent is 

Change fixes the full vega wallet raising errors for negative offsets during large price-movements.

### Testing
Passing all tests locally.

### Breaking Changes
None
