### PR TITLE
feat: network_service upgrades

### DIFF
--- a/vega_sim/environment/environment.py
+++ b/vega_sim/environment/environment.py
@@ -402,6 +402,8 @@ class NetworkEnvironment(MarketEnvironmentWithState):
         if self._vega is None:
             with VegaServiceNetwork(
                 use_full_vega_wallet=True,
+                run_with_wallet = True,
+                run_with_console = True,
             ) as vega:
                 return self._run(vega)
         else:

--- a/vega_sim/environment/environment.py
+++ b/vega_sim/environment/environment.py
@@ -402,8 +402,8 @@ class NetworkEnvironment(MarketEnvironmentWithState):
         if self._vega is None:
             with VegaServiceNetwork(
                 use_full_vega_wallet=True,
-                run_with_wallet = True,
-                run_with_console = True,
+                run_with_wallet=True,
+                run_with_console=True,
             ) as vega:
                 return self._run(vega)
         else:

--- a/vega_sim/network_service.py
+++ b/vega_sim/network_service.py
@@ -45,6 +45,7 @@ from vega_sim.wallet.vega_wallet import VegaWallet
 from vega_sim.null_service import find_free_port, _popen_process
 
 from vega_sim.constants import DATA_NODE_GRPC_PORT
+from vega_sim.scenario.constants import Network
 
 logger = logging.getLogger(__name__)
 
@@ -158,14 +159,14 @@ class VegaServiceNetwork(VegaService):
 
     def __init__(
         self,
-        network: str,
+        network: Network,
         run_with_wallet: bool = True,
         run_with_console: bool = True,
     ):
         """Method initialises the class.
 
         Args:
-            network (str):
+            network (Network):
                 Defines which network to connect service to.
             run_with_wallet (bool, optional):
                 Defines whether to start a wallet process.
@@ -207,7 +208,7 @@ class VegaServiceNetwork(VegaService):
         self.proc = ctx.Process(
             target=manage_vega_processes,
             kwargs={
-                "network": self.network,
+                "network": self.network.value,
                 "log_dir": self.log_dir,
                 "run_with_wallet": self.run_with_wallet,
                 "run_with_console": self.run_with_console,
@@ -267,16 +268,16 @@ class VegaServiceNetwork(VegaService):
                 "vega_sim",
                 "bin",
                 "networks-internal",
-                self.network,
-                f"{self.network}.toml",
+                self.network.name.lower(),
+                f"{self.network.value}.toml",
             )
             internal_path = path.join(
                 getcwd(),
                 "vega_sim",
                 "bin",
                 "networks",
-                self.network,
-                f"{self.network}.toml",
+                self.network.name.lower(),
+                f"{self.network.value}.toml",
             )
 
             if path.exists(public_path):
@@ -288,7 +289,9 @@ class VegaServiceNetwork(VegaService):
                 add_network_config(internal_path)
 
             else:
-                raise ValueError(f"ERROR! {self.network} network does not exist")
+                raise ValueError(
+                    f"ERROR! {self.network.name.lower()} network does not exist"
+                )
 
         return self._network_config
 
@@ -342,7 +345,7 @@ if __name__ == "__main__":
 
     # Create a service connected to the fairground network.
     with VegaServiceNetwork(
-        network="fairground",
+        network=Network.FAIRGROUND,
         run_with_wallet=True,
         run_with_console=True,
     ) as vega:
@@ -356,7 +359,7 @@ if __name__ == "__main__":
 
     # Create a service connected to the stagnet3 network.
     with VegaServiceNetwork(
-        network="stagnet3",
+        network=Network.FAIRGROUND,
         run_with_wallet=True,
         run_with_console=True,
     ) as vega:

--- a/vega_sim/scenario/adhoc.py
+++ b/vega_sim/scenario/adhoc.py
@@ -20,7 +20,7 @@ def main():
     parser.add_argument(
         "--network",
         choices=[network.name for network in Network],
-        default=Network.NULLCHAIN.name,
+        default=Network.nullchain.name,
     )
     parser.add_argument(
         "-p",
@@ -38,7 +38,7 @@ def main():
 
     scenario.pause_every_n_steps = args.pause_every_n_steps
 
-    if Network[args.network] == Network.NULLCHAIN:
+    if Network[args.network] == Network.nullchain:
         with VegaServiceNull(
             run_with_console=args.console,
             launch_graphql=args.graphql,

--- a/vega_sim/scenario/adhoc.py
+++ b/vega_sim/scenario/adhoc.py
@@ -60,8 +60,8 @@ def main():
     else:
         with VegaServiceNetwork(
             network=Network[args.network].value,
-            automatic_consent=True,
-            no_version_check=True,
+            run_with_wallet=True,
+            run_with_console=True,
         ) as vega:
             scenario.run_iteration(
                 vega=vega,

--- a/vega_sim/scenario/adhoc.py
+++ b/vega_sim/scenario/adhoc.py
@@ -20,7 +20,7 @@ def main():
     parser.add_argument(
         "--network",
         choices=[network.name for network in Network],
-        default=Network.nullchain.name,
+        default=Network.NULLCHAIN.name,
     )
     parser.add_argument(
         "-p",
@@ -38,7 +38,7 @@ def main():
 
     scenario.pause_every_n_steps = args.pause_every_n_steps
 
-    if Network[args.network] == Network.nullchain:
+    if Network[args.network] == Network.NULLCHAIN:
         with VegaServiceNull(
             run_with_console=args.console,
             launch_graphql=args.graphql,
@@ -59,7 +59,7 @@ def main():
             )
     else:
         with VegaServiceNetwork(
-            network=Network[args.network].value,
+            network=Network[args.network],
             run_with_wallet=True,
             run_with_console=True,
         ) as vega:

--- a/vega_sim/scenario/common/agents.py
+++ b/vega_sim/scenario/common/agents.py
@@ -81,7 +81,7 @@ class MarketOrderTrader(StateAgentWithWallet):
         random_state: Optional[np.random.RandomState] = None,
         base_order_size: float = 1,
         key_name: str = None,
-        step_bias: Optional[float] = 0,
+        step_bias: Optional[float] = 1,
     ):
         super().__init__(wallet_name + str(tag), wallet_pass, key_name)
         self.initial_asset_mint = initial_asset_mint

--- a/vega_sim/scenario/common/utils/price_process.py
+++ b/vega_sim/scenario/common/utils/price_process.py
@@ -166,3 +166,29 @@ if __name__ == "__main__":
             end="2022-09-05 09:05:20",
         )
     )
+
+
+class LivePrice:
+    """Iterator for getting a live product price process.
+
+    Class is to be used when running the scenario on fairground incentives. The
+    iterator can be passed to the market-maker agent and the price-sensitive
+    agents to give them information regarding the live product price.
+
+    """
+
+    def __init__(self, product: str = "ADAUSDT"):
+        self.product = product
+
+    def __iter__(self):
+        return self
+
+    def __getitem__(self, index):
+        return self._get_price()
+
+    def __next__(self):
+        return self._get_price()
+
+    def _get_price(self):
+        url = f"https://api.binance.com/api/v3/avgPrice?symbol={self.product}"
+        return float(requests.get(url).json()["price"])

--- a/vega_sim/scenario/constants.py
+++ b/vega_sim/scenario/constants.py
@@ -2,8 +2,8 @@ from enum import Enum
 
 
 class Network(Enum):
-    nullchain = "nullchain"
-    stagnet1 = "stagnet1"
-    stagnet2 = "vegawallet-stagnet2"
-    stagnet3 = "stagnet3"
-    fairground = "fairground"
+    NULLCHAIN = "nullchain"
+    STAGNET1 = "stagnet1"
+    STAGNET2 = "vegawallet-stagnet2"
+    STAGNET3 = "stagnet3"
+    FAIRGROUND = "fairground"

--- a/vega_sim/scenario/constants.py
+++ b/vega_sim/scenario/constants.py
@@ -1,8 +1,9 @@
-from enum import Enum, auto
+from enum import Enum
 
 
 class Network(Enum):
-    NULLCHAIN = "nullchain"
-    STAGNET1 = "vegawallet-stagnet1"
-    STAGNET3 = "stagnet3"
-    FAIRGROUND = "fairground"
+    nullchain = "nullchain"
+    stagnet1 = "stagnet1"
+    stagnet2 = "stagnet2"
+    stagnet3 = "stagnet3"
+    fairground = "fairground"

--- a/vega_sim/scenario/constants.py
+++ b/vega_sim/scenario/constants.py
@@ -4,6 +4,6 @@ from enum import Enum
 class Network(Enum):
     nullchain = "nullchain"
     stagnet1 = "stagnet1"
-    stagnet2 = "stagnet2"
+    stagnet2 = "vegawallet-stagnet2"
     stagnet3 = "stagnet3"
     fairground = "fairground"

--- a/vega_sim/scenario/fairground/scenario.py
+++ b/vega_sim/scenario/fairground/scenario.py
@@ -227,7 +227,7 @@ class Fairground(Scenario):
             random_state if random_state is not None else np.random.RandomState()
         )
 
-        if network == Network.NULLCHAIN:
+        if network == Network.nullchain:
 
             self.price_process = self._get_price_process(random_state=random_state)
 
@@ -372,7 +372,7 @@ class Fairground(Scenario):
 
         agents = self._setup(network=network, random_state=random_state)
 
-        if network == Network.NULLCHAIN:
+        if network == Network.nullchain:
             env = MarketEnvironmentWithState(
                 agents=agents,
                 n_steps=self.n_steps,

--- a/vega_sim/scenario/fairground/scenario.py
+++ b/vega_sim/scenario/fairground/scenario.py
@@ -227,7 +227,7 @@ class Fairground(Scenario):
             random_state if random_state is not None else np.random.RandomState()
         )
 
-        if network == Network.nullchain:
+        if network == Network.NULLCHAIN:
 
             self.price_process = self._get_price_process(random_state=random_state)
 
@@ -372,7 +372,7 @@ class Fairground(Scenario):
 
         agents = self._setup(network=network, random_state=random_state)
 
-        if network == Network.nullchain:
+        if network == Network.NULLCHAIN:
             env = MarketEnvironmentWithState(
                 agents=agents,
                 n_steps=self.n_steps,

--- a/vega_sim/scenario/fairground/scenario.py
+++ b/vega_sim/scenario/fairground/scenario.py
@@ -27,6 +27,7 @@ from vega_sim.environment.environment import (
 from vega_sim.environment.agent import Agent
 from vega_sim.scenario.common.utils.price_process import (
     get_historic_price_series,
+    LivePrice,
     Granularity,
 )
 from vega_sim.scenario.common.agents import (
@@ -47,32 +48,6 @@ from vega_sim.scenario.fairground.agents import (
     MOMENTUM_MARKET_ORDER_AGENT_KEYS,
     SENSITIVE_MARKET_ORDER_AGENT_KEYS,
 )
-
-
-class LivePrice:
-    """Iterator for getting a live product price process.
-
-    Class is to be used when running the scenario on fairground incentives. The
-    iterator can be passed to the market-maker agent and the price-sensitive
-    agents to give them information regarding the live product price.
-
-    """
-
-    def __init__(self, product: str = "ADAUSDT"):
-        self.product = product
-
-    def __iter__(self):
-        return self
-
-    def __getitem__(self, index):
-        return self._get_price()
-
-    def __next__(self):
-        return self._get_price()
-
-    def _get_price(self):
-        url = f"https://api.binance.com/api/v3/avgPrice?symbol={self.product}"
-        return float(requests.get(url).json()["price"])
 
 
 # Set default scenario arguments

--- a/vega_sim/scenario/network/scenario.py
+++ b/vega_sim/scenario/network/scenario.py
@@ -131,7 +131,7 @@ if __name__ == "__main__":
 
     with VegaServiceNetwork(
         network=("fairground" if args.network is None else args.network),
-        automatic_consent=True,
-        no_version_check=True,
+        run_with_wallet=True,
+        run_with_console=True,
     ) as vega:
         scenario.run_iteration(vega=vega)

--- a/vega_sim/scenario/network/scenario.py
+++ b/vega_sim/scenario/network/scenario.py
@@ -130,7 +130,9 @@ if __name__ == "__main__":
     )
 
     with VegaServiceNetwork(
-        network=("fairground" if args.network is None else args.network),
+        network=(
+            Network["FAIRGROUND"] if args.network is None else Network[args.network]
+        ),
         run_with_wallet=True,
         run_with_console=True,
     ) as vega:


### PR DESCRIPTION
## Description
Combo of minor fixes and upgrades to the `network_service.py` module.

#### Features:
- Aligns how `VegaServiceNetwork` manages services with how `VegaServiceNull` manages services.
- Allows `VegaServiceNetwork` to launch a console for the specified network.

#### Fixes: 
- Corrects faulty default `step_bias` value in the `MarketOrderTrader`.
- Adds a missing `initial_mint` arg to the `ConfigurableMarketManager` agent.
- Updates the `Network` enum to match the latest network config files.

#### Refactors:
- Moves `LivePrice` iterator class to somewhere more sensible. 

## Testing
Passing all tests locally.