### PR TITLE
fix: correct random_walk logic

### DIFF
--- a/vega_sim/scenario/common/utils/price_process.py
+++ b/vega_sim/scenario/common/utils/price_process.py
@@ -46,9 +46,9 @@ def random_walk(
     S[0] = starting_price
 
     for _ in range(100):
-        dW = random_state.randn(num_steps)
+        dW = random_state.randn(num_steps + 1)
         # Simulate external midprice
-        for i in range(1, num_steps):
+        for i in range(1, len(S)):
             S[i] = S[i - 1] + drift + sigma * dW[i]
 
         # market decimal place


### PR DESCRIPTION
### Description
Running a parameter test:

`python -m vega_sim.parameter_test.run -c TauScaling_Curve
`

Would throw this exception:

`Exception: Negative price generated with current random seed. Please try another or don't specify one
`

Error thrown as the loop calculating the next random price was not long enough, i.e. `S[-1]` left as `0` so the exception raised.

PR fixes `random_walk`.


### Testing
Passing all tests locally.
