### PR TITLE
feat: add one_off_transfers method

### DIFF
--- a/tests/integration/test_trading.py
+++ b/tests/integration/test_trading.py
@@ -4,6 +4,7 @@ from tests.integration.utils.fixtures import (
     vega_service_with_market,
     vega_service,
     create_and_faucet_wallet,
+    ASSET_NAME,
     WalletConfig,
 )
 from vega_sim.null_service import VegaServiceNull
@@ -11,6 +12,8 @@ import vega_sim.proto.vega as vega_protos
 
 
 LIQ = WalletConfig("liq", "liq")
+PARTY_A = WalletConfig("party_a", "party_a")
+PARTY_B = WalletConfig("party_b", "party_b")
 
 
 @pytest.mark.integration
@@ -132,3 +135,44 @@ def test_submit_amend_liquidity(vega_service_with_market: VegaServiceNull):
 
     for vol, exp_vol in zip(ask_volumes, expected_ask_volumes):
         assert vol == exp_vol
+
+
+@pytest.mark.integration
+def test_one_off_transfer(vega_service_with_market: VegaServiceNull):
+    vega = vega_service_with_market
+    market_id = vega.all_markets()[0].id
+
+    vega.wait_for_total_catchup()
+
+    create_and_faucet_wallet(vega=vega, wallet=PARTY_A, amount=1e3)
+    vega.wait_for_total_catchup()
+    create_and_faucet_wallet(vega=vega, wallet=PARTY_B, amount=1e3)
+    vega.wait_for_total_catchup()
+
+    asset_id = vega.find_asset_id(symbol=ASSET_NAME, raise_on_missing=True)
+
+    vega.one_off_transfer(
+        from_wallet_name=PARTY_A.name,
+        from_account_type=vega_protos.vega.ACCOUNT_TYPE_GENERAL,
+        to_wallet_name=PARTY_B.name,
+        to_account_type=vega_protos.vega.ACCOUNT_TYPE_GENERAL,
+        asset=asset_id,
+        amount=500,
+    )
+
+    vega.wait_for_total_catchup()
+    vega.wait_fn(10)
+
+    party_a_accounts = vega.party_account(
+        wallet_name=PARTY_A.name,
+        asset_id=asset_id,
+        market_id=market_id,
+    )
+    party_b_accounts = vega.party_account(
+        wallet_name=PARTY_B.name,
+        asset_id=asset_id,
+        market_id=market_id,
+    )
+
+    assert party_a_accounts.general == 500
+    assert party_b_accounts.general == 1500

--- a/tests/integration/utils/fixtures.py
+++ b/tests/integration/utils/fixtures.py
@@ -128,12 +128,6 @@ def build_basic_market(
     )
     vega.wait_for_total_catchup()
 
-    vega.update_network_parameter(
-        proposal_wallet=MM_WALLET.name,
-        parameter="transfer.fee.factor",
-        new_value="0",
-    )
-
 
 @pytest.fixture
 def vega_service():

--- a/tests/integration/utils/fixtures.py
+++ b/tests/integration/utils/fixtures.py
@@ -128,6 +128,12 @@ def build_basic_market(
     )
     vega.wait_for_total_catchup()
 
+    vega.update_network_parameter(
+        proposal_wallet=MM_WALLET.name,
+        parameter="transfer.fee.factor",
+        new_value="0",
+    )
+
 
 @pytest.fixture
 def vega_service():

--- a/vega_sim/service.py
+++ b/vega_sim/service.py
@@ -1861,8 +1861,32 @@ class VegaService(ABC):
         reference: Optional[str] = None,
         from_key_name: Optional[str] = None,
         to_key_name: Optional[str] = None,
-        delay: Optional[int] = 0,
+        delay: Optional[int] = None,
     ):
+        """Submit a one off transfer command.        
+
+        Args:
+            from_wallet_name (str):
+                Name of wallet to transfer from.
+            to_wallet_name (str):
+                Name of wallet to transfer to.
+            from_account_type (vega_protos.vega.AccountType):
+                Type of Vega account to transfer from.
+            to_account_type (vega_protos.vega.AccountType):
+                Type of Vega account to transfer to.
+            asset (str):
+                Id of asset to transfer.
+            amount (float):
+                Amount of asset to transfer.
+            reference (Optional[str], optional):
+                Reference to assign to transfer. Defaults to None.
+            from_key_name (Optional[str], optional):
+                Name of key in wallet to send from. Defaults to None.
+            to_key_name (Optional[str], optional):
+                Name of key in wallet to send to. Defaults to None.
+            delay (Optional[int], optional):
+                Delay in seconds to add before transfer is sent. Defaults to None.
+        """
 
         adp = self.asset_decimals[asset]
 

--- a/vega_sim/service.py
+++ b/vega_sim/service.py
@@ -1863,7 +1863,7 @@ class VegaService(ABC):
         to_key_name: Optional[str] = None,
         delay: Optional[int] = None,
     ):
-        """Submit a one off transfer command.        
+        """Submit a one off transfer command.
 
         Args:
             from_wallet_name (str):

--- a/vega_sim/service.py
+++ b/vega_sim/service.py
@@ -1849,3 +1849,36 @@ class VegaService(ABC):
     def ping_datanode(self):
         """Ping datanode endpoint to check health of connection"""
         data.ping(data_client=self.trading_data_client_v2)
+
+    def one_off_transfer(
+        self,
+        from_wallet_name: str,
+        to_wallet_name: str,
+        from_account_type: vega_protos.vega.AccountType,
+        to_account_type: vega_protos.vega.AccountType,
+        asset: str,
+        amount: float,
+        reference: Optional[str] = None,
+        from_key_name: Optional[str] = None,
+        to_key_name: Optional[str] = None,
+        delay: Optional[int] = 0,
+    ):
+
+        adp = self.asset_decimals[asset]
+
+        one_off = vega_protos.commands.v1.commands.OneOffTransfer()
+        if delay is not None:
+            setattr(one_off, "deliver_on", self.get_blockchain_time() + delay)
+
+        trading.transfer(
+            wallet=self.wallet,
+            wallet_name=from_wallet_name,
+            key_name=from_key_name,
+            from_account_type=from_account_type,
+            to=self.wallet.public_key(name=to_wallet_name, key_name=to_key_name),
+            to_account_type=to_account_type,
+            asset=asset,
+            amount=str(num_to_padded_int(amount, adp)),
+            reference=reference,
+            one_off=one_off,
+        )

--- a/vega_sim/vegahome/genesis.json
+++ b/vega_sim/vegahome/genesis.json
@@ -137,6 +137,7 @@
       "spam.protection.max.votes": "3",
       "spam.protection.proposal.min.tokens": "100000000000000000000000",
       "spam.protection.voting.min.tokens": "100000000000000000000",
+      "transfer.fee.factor": "0",
       "validators.delegation.minAmount": "1",
       "validators.epoch.length": "24h0m0s",
       "validators.vote.required": "0.67"


### PR DESCRIPTION
### Description
Adds a `one_off_transfer` method to `VegaService`.

### Testing
Integration tests added to check following cases:

- If no delay: funds taken from account and transferred to account instantly.
- If delay: funds taken from account instantly but only transferred to account on deliver time.

Passing all tests locally.