### PR TITLE
fix: mm order scaling

### DIFF
--- a/vega_sim/scenario/common/agents.py
+++ b/vega_sim/scenario/common/agents.py
@@ -1177,6 +1177,9 @@ class ShapedMarketMaker(StateAgentWithWallet):
 
         for vol, price in orders:
 
+            if price <= 0:
+                continue
+
             p = probability_of_trading(
                 price=price,
                 side=side,

--- a/vega_sim/service.py
+++ b/vega_sim/service.py
@@ -632,8 +632,8 @@ class VegaService(ABC):
             volume,
             self.market_pos_decimals[market_id],
         )
-        if submit_volume == 0:
-            msg = "Not submitting order as volume is 0"
+        if submit_volume <= 0:
+            msg = "Not submitting order as volume is 0 or less."
             if wait:
                 raise Exception(msg)
             else:

--- a/vega_sim/service.py
+++ b/vega_sim/service.py
@@ -639,6 +639,23 @@ class VegaService(ABC):
             else:
                 logger.debug(msg)
                 return
+
+        submit_price = (
+            num_to_padded_int(
+                price,
+                self.market_price_decimals[market_id],
+            )
+            if price is not None
+            else None
+        )
+        if submit_price is not None and submit_price <= 0:
+            msg = "Not submitting order as price is 0 or less."
+            if wait:
+                raise Exception(msg)
+            else:
+                logger.debug(msg)
+                return
+
         return trading.submit_order(
             wallet=self.wallet,
             wallet_name=trading_wallet,
@@ -648,14 +665,7 @@ class VegaService(ABC):
             time_in_force=time_in_force,
             side=side,
             volume=submit_volume,
-            price=str(
-                num_to_padded_int(
-                    price,
-                    self.market_price_decimals[market_id],
-                )
-            )
-            if price is not None
-            else None,
+            price=str(submit_price),
             expires_at=expires_at,
             pegged_order=vega_protos.vega.PeggedOrder(
                 reference=pegged_order.reference,


### PR DESCRIPTION
### Description
Bug where orders with negative `prices` were leading to negative `provided_liquidity` values from the `_calculate_liquidity_method` (and therefore negative `scaling_factor` and size `values`).

Orders with negative prices are no longer used to calculate `provided_liquidity`.

Additionally checks have been added to all `service` methods which can submit or amend orders as well as create `OrderSubmission` or `OrderAmendment` objects. Checks prevent orders with negatives `price` or `size` values being submitted.

### Testing
Passing all test locally.

### Breaking Changes
AFAIK none.
