### PR TITLE
feat: transfer monitoring

### DIFF
--- a/tests/integration/test_trading.py
+++ b/tests/integration/test_trading.py
@@ -172,6 +172,13 @@ def test_one_off_transfer(vega_service_with_market: VegaServiceNull):
         market_id=market_id,
     )
 
+    all_transfers_t1 = vega.list_transfers(
+        wallet_name=PARTY_A.name,
+    )
+    live_transfers_t1 = vega.transfer_status_from_feed(live_only=True)
+
+    assert len(all_transfers_t1) == 1
+    assert len(live_transfers_t1) == 0
     assert party_a_accounts_t1.general == 500
     assert party_b_accounts_t1.general == 1500
 
@@ -199,6 +206,13 @@ def test_one_off_transfer(vega_service_with_market: VegaServiceNull):
         market_id=market_id,
     )
 
+    all_transfers_t2 = vega.list_transfers(
+        wallet_name=PARTY_A.name,
+    )
+    live_transfers_t2 = vega.transfer_status_from_feed(live_only=True)
+
+    assert len(all_transfers_t2) == 2
+    assert len(live_transfers_t2) == 1
     assert party_a_accounts_t2.general == 500
     assert party_b_accounts_t2.general == 1000
 
@@ -216,5 +230,12 @@ def test_one_off_transfer(vega_service_with_market: VegaServiceNull):
         market_id=market_id,
     )
 
+    all_transfers_t3 = vega.list_transfers(
+        wallet_name=PARTY_A.name,
+    )
+    live_transfers_t3 = vega.transfer_status_from_feed(live_only=True)
+
+    assert len(all_transfers_t3) == 2
+    assert len(live_transfers_t3) == 0
     assert party_a_accounts_t3.general == 1000
     assert party_b_accounts_t3.general == 1000

--- a/tests/vega_sim/api/test_data.py
+++ b/tests/vega_sim/api/test_data.py
@@ -647,9 +647,10 @@ def test_order_subscription(mkt_price_mock, mkt_pos_mock, core_servicer_and_port
     for order in orders:
         assert order.id == next(queue).id
 
+
 @patch("vega_sim.api.data.asset_decimals")
 def test_transfer_subscription(mk_asset_decimals, core_servicer_and_port):
-    
+
     mk_asset_decimals.return_value = 1
     transfers = [
         events_protos.Transfer(
@@ -755,7 +756,10 @@ def test_transfer_subscription(mk_asset_decimals, core_servicer_and_port):
     def ObserveEventBus(self, request, context):
         for transfer_chunk in [transfers[:3], transfers[3:6], transfers[6:]]:
             yield vega_protos.api.v1.core.ObserveEventBusResponse(
-                events=[events_protos.BusEvent(transfer=transfer) for transfer in transfer_chunk]
+                events=[
+                    events_protos.BusEvent(transfer=transfer)
+                    for transfer in transfer_chunk
+                ]
             )
 
     server, port, mock_servicer = core_servicer_and_port
@@ -943,7 +947,7 @@ def test_list_transfers(
         timestamp=000000000,
         reason="reason",
         one_off=events_protos.OneOffTransfer(deliver_on=000000000),
-        recurring=events_protos.RecurringTransfer()
+        recurring=events_protos.RecurringTransfer(),
     )
 
     node = events_protos.Transfer(

--- a/tests/vega_sim/api/test_data.py
+++ b/tests/vega_sim/api/test_data.py
@@ -31,6 +31,7 @@ from vega_sim.api.data import (
     market_price_decimals,
     open_orders_by_market,
     order_subscription,
+    transfer_subscription,
     party_account,
     list_transfers,
 )
@@ -645,6 +646,128 @@ def test_order_subscription(mkt_price_mock, mkt_pos_mock, core_servicer_and_port
     queue = order_subscription(data_client=data_client, trading_data_client=None)
     for order in orders:
         assert order.id == next(queue).id
+
+@patch("vega_sim.api.data.asset_decimals")
+def test_transfer_subscription(mk_asset_decimals, core_servicer_and_port):
+    
+    mk_asset_decimals.return_value = 1
+    transfers = [
+        events_protos.Transfer(
+            id="id1",
+            from_account_type=vega_protos.vega.ACCOUNT_TYPE_GENERAL,
+            to="party2",
+            to_account_type=vega_protos.vega.ACCOUNT_TYPE_GENERAL,
+            asset="asset1",
+            amount="100000",
+            reference="reference",
+            status=events_protos.Transfer.Status.STATUS_DONE,
+            timestamp=000000000,
+            reason="reason",
+            one_off=events_protos.OneOffTransfer(deliver_on=000000000),
+            recurring=events_protos.RecurringTransfer(),
+        ),
+        events_protos.Transfer(
+            id="id2",
+            from_account_type=vega_protos.vega.ACCOUNT_TYPE_GENERAL,
+            to="party2",
+            to_account_type=vega_protos.vega.ACCOUNT_TYPE_GENERAL,
+            asset="asset1",
+            amount="100000",
+            reference="reference",
+            status=events_protos.Transfer.Status.STATUS_DONE,
+            timestamp=000000000,
+            reason="reason",
+            one_off=events_protos.OneOffTransfer(deliver_on=000000000),
+            recurring=events_protos.RecurringTransfer(),
+        ),
+        events_protos.Transfer(
+            id="id3",
+            from_account_type=vega_protos.vega.ACCOUNT_TYPE_GENERAL,
+            to="party2",
+            to_account_type=vega_protos.vega.ACCOUNT_TYPE_GENERAL,
+            asset="asset1",
+            amount="100000",
+            reference="reference",
+            status=events_protos.Transfer.Status.STATUS_DONE,
+            timestamp=000000000,
+            reason="reason",
+            one_off=events_protos.OneOffTransfer(deliver_on=000000000),
+            recurring=events_protos.RecurringTransfer(),
+        ),
+        events_protos.Transfer(
+            id="id4",
+            from_account_type=vega_protos.vega.ACCOUNT_TYPE_GENERAL,
+            to="party2",
+            to_account_type=vega_protos.vega.ACCOUNT_TYPE_GENERAL,
+            asset="asset1",
+            amount="100000",
+            reference="reference",
+            status=events_protos.Transfer.Status.STATUS_DONE,
+            timestamp=000000000,
+            reason="reason",
+            one_off=events_protos.OneOffTransfer(deliver_on=000000000),
+            recurring=events_protos.RecurringTransfer(),
+        ),
+        events_protos.Transfer(
+            id="id5",
+            from_account_type=vega_protos.vega.ACCOUNT_TYPE_GENERAL,
+            to="party2",
+            to_account_type=vega_protos.vega.ACCOUNT_TYPE_GENERAL,
+            asset="asset1",
+            amount="100000",
+            reference="reference",
+            status=events_protos.Transfer.Status.STATUS_DONE,
+            timestamp=000000000,
+            reason="reason",
+            one_off=events_protos.OneOffTransfer(deliver_on=000000000),
+            recurring=events_protos.RecurringTransfer(),
+        ),
+        events_protos.Transfer(
+            id="id6",
+            from_account_type=vega_protos.vega.ACCOUNT_TYPE_GENERAL,
+            to="party2",
+            to_account_type=vega_protos.vega.ACCOUNT_TYPE_GENERAL,
+            asset="asset1",
+            amount="100000",
+            reference="reference",
+            status=events_protos.Transfer.Status.STATUS_DONE,
+            timestamp=000000000,
+            reason="reason",
+            one_off=events_protos.OneOffTransfer(deliver_on=000000000),
+            recurring=events_protos.RecurringTransfer(),
+        ),
+        events_protos.Transfer(
+            id="id7",
+            from_account_type=vega_protos.vega.ACCOUNT_TYPE_GENERAL,
+            to="party2",
+            to_account_type=vega_protos.vega.ACCOUNT_TYPE_GENERAL,
+            asset="asset1",
+            amount="100000",
+            reference="reference",
+            status=events_protos.Transfer.Status.STATUS_DONE,
+            timestamp=000000000,
+            reason="reason",
+            one_off=events_protos.OneOffTransfer(deliver_on=000000000),
+            recurring=events_protos.RecurringTransfer(),
+        ),
+    ]
+
+    def ObserveEventBus(self, request, context):
+        for transfer_chunk in [transfers[:3], transfers[3:6], transfers[6:]]:
+            yield vega_protos.api.v1.core.ObserveEventBusResponse(
+                events=[events_protos.BusEvent(transfer=transfer) for transfer in transfer_chunk]
+            )
+
+    server, port, mock_servicer = core_servicer_and_port
+    mock_servicer.ObserveEventBus = ObserveEventBus
+
+    add_CoreServiceServicer_to_server(mock_servicer(), server)
+
+    data_client = VegaCoreClient(f"localhost:{port}")
+
+    queue = transfer_subscription(data_client=data_client, trading_data_client=None)
+    for transfer in transfers:
+        assert transfer.id == next(queue).id
 
 
 @patch("vega_sim.api.data.asset_decimals")

--- a/tests/vega_sim/api/test_data.py
+++ b/tests/vega_sim/api/test_data.py
@@ -18,6 +18,7 @@ from vega_sim.api.data import (
     MarginLevels,
     MissingAssetError,
     Order,
+    Transfer,
     OrdersBySide,
     Trade,
     asset_decimals,
@@ -31,6 +32,7 @@ from vega_sim.api.data import (
     open_orders_by_market,
     order_subscription,
     party_account,
+    list_transfers,
 )
 from vega_sim.grpc.client import (
     VegaCoreClient,
@@ -797,3 +799,76 @@ def test_get_trades(
     )
 
     assert res == expected
+
+
+@patch("vega_sim.api.data.asset_decimals")
+def test_list_transfers(
+    mk_asset_decimals,
+    trading_data_v2_servicer_and_port,
+):
+
+    expected = Transfer(
+        id="id1",
+        party_from="party1",
+        from_account_type=vega_protos.vega.ACCOUNT_TYPE_GENERAL,
+        party_to="party2",
+        to_account_type=vega_protos.vega.ACCOUNT_TYPE_GENERAL,
+        asset="asset1",
+        amount=1000.0,
+        reference="reference",
+        status=events_protos.Transfer.Status.STATUS_DONE,
+        timestamp=000000000,
+        reason="reason",
+        one_off=events_protos.OneOffTransfer(deliver_on=000000000),
+        recurring=events_protos.RecurringTransfer()
+    )
+
+    node = events_protos.Transfer(
+        id="id1",
+        from_account_type=vega_protos.vega.ACCOUNT_TYPE_GENERAL,
+        to="party2",
+        to_account_type=vega_protos.vega.ACCOUNT_TYPE_GENERAL,
+        asset="asset1",
+        amount="100000",
+        reference="reference",
+        status=events_protos.Transfer.Status.STATUS_DONE,
+        timestamp=000000000,
+        reason="reason",
+        one_off=events_protos.OneOffTransfer(deliver_on=000000000),
+        recurring=events_protos.RecurringTransfer(),
+    )
+    setattr(node, "from", "party1")
+
+    def ListTransfers(self, request, context):
+        return data_node_protos_v2.trading_data.ListTransfersResponse(
+            transfers=data_node_protos_v2.trading_data.TransferConnection(
+                page_info=data_node_protos_v2.trading_data.PageInfo(
+                    has_next_page=False,
+                    has_previous_page=False,
+                    start_cursor="",
+                    end_cursor="",
+                ),
+                edges=[
+                    data_node_protos_v2.trading_data.TransferEdge(
+                        cursor="cursor",
+                        node=node,
+                    )
+                ],
+            )
+        )
+
+    mk_asset_decimals.return_value = 2
+
+    server, port, mock_servicer = trading_data_v2_servicer_and_port
+    mock_servicer.ListTransfers = ListTransfers
+
+    add_TradingDataServiceServicer_v2_to_server(mock_servicer(), server)
+
+    data_client = VegaTradingDataClientV2(f"localhost:{port}")
+    res = list_transfers(
+        data_client=data_client,
+        party_id="party2",
+        direction=data_node_protos_v2.trading_data.TRANSFER_DIRECTION_TRANSFER_TO_OR_FROM,
+    )
+
+    assert res == [expected]

--- a/tests/vega_sim/api/test_data_raw.py
+++ b/tests/vega_sim/api/test_data_raw.py
@@ -23,7 +23,7 @@ from vega_sim.api.data_raw import (
     market_info,
     order_status,
     positions_by_market,
-    order_subscription,
+    observe_event_bus,
     margin_levels,
     list_transfers,
 )
@@ -481,7 +481,7 @@ def test_liquidity_provisions(trading_data_v2_servicer_and_port):
     assert res[0].market_id == "MARKET"
 
 
-def test_order_subscription(core_servicer_and_port):
+def test_observe_event_bus(core_servicer_and_port):
     def ObserveEventBus(self, request, context):
         orders = [
             vega_protos.vega.Order(
@@ -616,8 +616,9 @@ def test_order_subscription(core_servicer_and_port):
 
     data_client = VegaCoreClient(f"localhost:{port}")
 
-    queue = order_subscription(
+    queue = observe_event_bus(
         data_client=data_client,
+        type=[events_protos.BUS_EVENT_TYPE_ORDER],
     )
 
     batch_one = next(queue)

--- a/vega_sim/api/data.py
+++ b/vega_sim/api/data.py
@@ -7,6 +7,7 @@ import vega_sim.api.data_raw as data_raw
 import vega_sim.grpc.client as vac
 import vega_sim.proto.data_node.api.v2 as data_node_protos_v2
 import vega_sim.proto.vega as vega_protos
+import vega_sim.proto.vega.events.v1.events_pb2 as events_protos
 from vega_sim.api.helpers import num_from_padded_int
 
 
@@ -777,8 +778,11 @@ def order_subscription(
         Iterable[Order], Infinite iterable of order updates
     """
 
-    order_stream = data_raw.order_subscription(
-        data_client=data_client, market_id=market_id, party_id=party_id
+    order_stream = data_raw.observe_event_bus(
+        data_client=data_client,
+        type=[events_protos.BUS_EVENT_TYPE_ORDER],
+        market_id=market_id,
+        party_id=party_id,
     )
 
     def _order_gen(

--- a/vega_sim/api/data.py
+++ b/vega_sim/api/data.py
@@ -945,7 +945,7 @@ def ping(data_client: vac.VegaTradingDataClientV2):
 
 def list_transfers(
     data_client: vac.VegaTradingDataClientV2,
-    party_id: str,
+    party_id: Optional[str] = None,
     direction: data_node_protos_v2.trading_data.TransferDirection = None,
 ):
 

--- a/vega_sim/api/data.py
+++ b/vega_sim/api/data.py
@@ -947,7 +947,7 @@ def list_transfers(
     data_client: vac.VegaTradingDataClientV2,
     party_id: Optional[str] = None,
     direction: data_node_protos_v2.trading_data.TransferDirection = None,
-):
+) -> List[Transfer]:
 
     transfers = data_raw.list_transfers(
         data_client=data_client,

--- a/vega_sim/api/data.py
+++ b/vega_sim/api/data.py
@@ -948,6 +948,20 @@ def list_transfers(
     party_id: Optional[str] = None,
     direction: data_node_protos_v2.trading_data.TransferDirection = None,
 ) -> List[Transfer]:
+    """Returns a list of processed transfers.
+
+    Args:
+        data_client (vac.VegaTradingDataClientV2):
+            An instantiated gRPC trading data client
+        party_id (Optional[str], optional):
+            Public key for the specified party. Defaults to None.
+        direction (Optional[data_node_protos_v2.trading_data.TransferDirection], optional):
+            Direction of transfers to return. Defaults to None.
+
+    Returns:
+        List[Transfer]:
+            A list of processed Transfer objects for the specified party and direction.
+    """
 
     transfers = data_raw.list_transfers(
         data_client=data_client,

--- a/vega_sim/api/data_raw.py
+++ b/vega_sim/api/data_raw.py
@@ -316,18 +316,21 @@ def observe_event_bus(
     market_id: Optional[str] = None,
     party_id: Optional[str] = None,
 ) -> Iterable[vega_protos.api.v1.core.ObserveEventBusResponse]:
-    """Subscribe to a stream of Order updates from the data-node.
-    The stream of orders returned from this function is an iterable which
+    """Subscribe to a stream of event updates from the data-node.
+    The stream of events returned from this function is an iterable which
     does not end and will continue to tick another order update whenever
     one is received.
 
     Args:
+        type:
+            Optional[list], If provided only return events of these types
         market_id:
-            Optional[str], If provided, only update orders from this market
+            Optional[str], If provided, only update events from this market
         party_id:
-            Optional[str], If provided, only update orders from this party
+            Optional[str], If provided, only update events from this party
     Returns:
-        Iterable[List[vega.Order]], Infinite iterable of lists of order updates
+        Iterable[vega_protos.api.v1.core.ObserveEventBusResponse]:
+            Infinite iterable of lists of events updates
     """
     return data_client.ObserveEventBus(
         iter([vega_protos.api.v1.core.ObserveEventBusRequest(type=type)])
@@ -389,6 +392,20 @@ def list_transfers(
     party_id: Optional[str] = None,
     direction: Optional[data_node_protos_v2.trading_data.TransferDirection] = None,
 ) -> List[events_protos.Transfer]:
+    """Returns a list of raw transfers.
+
+    Args:
+        data_client (vac.VegaTradingDataClientV2):
+            An instantiated gRPC trading data client
+        party_id (Optional[str], optional):
+            Public key for the specified party. Defaults to None.
+        direction (Optional[data_node_protos_v2.trading_data.TransferDirection], optional):
+            Direction of transfers to return. Defaults to None.
+
+    Returns:
+        List[events_protos.Transfer]:
+            A list of Vega Transfer proto objects.
+    """
 
     base_request = data_node_protos_v2.trading_data.ListTransfersRequest(
         pubkey=party_id, direction=direction

--- a/vega_sim/api/data_raw.py
+++ b/vega_sim/api/data_raw.py
@@ -387,3 +387,24 @@ def get_network_parameter(
     return data_client.GetNetworkParameter(
         data_node_protos_v2.trading_data.GetNetworkParameterRequest(key=key),
     ).network_parameter
+
+
+def list_transfers(
+    data_client: vac.VegaTradingDataClientV2,
+    party_id: str,
+    direction: Optional[data_node_protos_v2.trading_data.TransferDirection] = None,
+) -> Union[str, int, float]:
+
+    direction = (
+        direction
+        if direction is not None
+        else data_node_protos_v2.trading_data.TRANSFER_DIRECTION_TRANSFER_TO_OR_FROM
+    )
+
+    return unroll_v2_pagination(
+        data_node_protos_v2.trading_data.ListTransfersRequest(
+            pubkey=party_id, direction=direction
+        ),
+        request_func=lambda x: data_client.ListTransfers(x).transfers,
+        extraction_func=lambda res: [i.node for i in res.edges],
+    )

--- a/vega_sim/api/data_raw.py
+++ b/vega_sim/api/data_raw.py
@@ -310,8 +310,9 @@ def liquidity_provisions(
     )
 
 
-def order_subscription(
+def observe_event_bus(
     data_client: vac.VegaCoreClient,
+    type: Optional[list],
     market_id: Optional[str] = None,
     party_id: Optional[str] = None,
 ) -> Iterable[vega_protos.api.v1.core.ObserveEventBusResponse]:
@@ -329,13 +330,7 @@ def order_subscription(
         Iterable[List[vega.Order]], Infinite iterable of lists of order updates
     """
     return data_client.ObserveEventBus(
-        iter(
-            [
-                vega_protos.api.v1.core.ObserveEventBusRequest(
-                    type=[events_protos.BUS_EVENT_TYPE_ORDER]
-                )
-            ]
-        )
+        iter([vega_protos.api.v1.core.ObserveEventBusRequest(type=type)])
     )
 
 

--- a/vega_sim/api/data_raw.py
+++ b/vega_sim/api/data_raw.py
@@ -388,7 +388,7 @@ def list_transfers(
     data_client: vac.VegaTradingDataClientV2,
     party_id: Optional[str] = None,
     direction: Optional[data_node_protos_v2.trading_data.TransferDirection] = None,
-) -> Union[str, int, float]:
+) -> List[events_protos.Transfer]:
 
     base_request = data_node_protos_v2.trading_data.ListTransfersRequest(
         pubkey=party_id, direction=direction

--- a/vega_sim/null_service.py
+++ b/vega_sim/null_service.py
@@ -522,6 +522,7 @@ class VegaServiceNull(VegaService):
         seconds_per_block: int = 1,
         use_full_vega_wallet: bool = False,
         start_order_feed: bool = True,
+        start_transfer_feed: bool = True,
         retain_log_files: bool = False,
         launch_graphql: bool = False,
         store_transactions: bool = True,
@@ -556,6 +557,7 @@ class VegaServiceNull(VegaService):
         self.log_dir = tempfile.mkdtemp(prefix="vega-sim-")
 
         self._start_order_feed = start_order_feed
+        self._start_transfer_feed = start_transfer_feed
         self.launch_graphql = launch_graphql
         self.replay_from_path = replay_from_path
 
@@ -698,6 +700,8 @@ class VegaServiceNull(VegaService):
 
         if self._start_order_feed:
             self.start_order_monitoring()
+        if self._start_transfer_feed:
+            self.start_transfer_monitoring()
 
     # Class internal as at some point the host may vary as well as the port
     @staticmethod

--- a/vega_sim/service.py
+++ b/vega_sim/service.py
@@ -1478,6 +1478,16 @@ class VegaService(ABC):
             self.trading_data_client_v2,
         )
 
+        base_transfers = []
+
+        base_transfers.extend(
+            data.list_transfers(data_client=self.trading_data_client_v2)
+        )
+
+        with self.transfers_lock:
+            for t in base_transfers:
+                self._transfer_state_from_feed.setdefault(t.party_to, {})[t.id] = t
+
         self.transfer_thread = threading.Thread(
             target=self._monitor_transfer_stream,
             args=(self.transfer_queue,),

--- a/vega_sim/service.py
+++ b/vega_sim/service.py
@@ -21,7 +21,10 @@ import vega_sim.api.trading as trading
 import vega_sim.grpc.client as vac
 import vega_sim.proto.vega as vega_protos
 import vega_sim.proto.vega.data.v1 as oracles_protos
+import vega_sim.proto.vega.events.v1 as events_protos
 import vega_sim.proto.vega.data_source_pb2 as data_source_protos
+import vega_sim.proto.data_node.api.v2 as data_node_protos_v2
+
 from vega_sim.api.helpers import (
     forward,
     num_to_padded_int,
@@ -131,7 +134,9 @@ class VegaService(ABC):
 
         self.order_thread = None
         self.orders_lock = threading.RLock()
+        self.transfers_lock = threading.RLock()
         self._order_state_from_feed = {}
+        self._transfer_state_from_feed = {}
 
     @property
     def market_price_decimals(self) -> int:
@@ -1370,6 +1375,19 @@ class VegaService(ABC):
             .get(party_id, {})
         )
 
+    def transfer_status_from_feed(self, live_only: bool = True):
+
+        datetime = self.get_blockchain_time()
+
+        with self.transfers_lock:
+            transfers_dict = {}
+            for party_id, party_transfers in self._transfer_state_from_feed.items():
+                for transfer_id, transfer in party_transfers.items():
+                    deliver_on = int(transfer.one_off.deliver_on)
+                    if not live_only or (deliver_on != 0 and datetime < deliver_on):
+                        transfers_dict.setdefault(party_id, {})[transfer_id] = transfer
+        return transfers_dict
+
     @raw_data
     def liquidity_provisions(
         self,
@@ -1451,6 +1469,22 @@ class VegaService(ABC):
         )
         self.order_thread.start()
 
+    def start_transfer_monitoring(
+        self,
+    ):
+
+        self.transfer_queue = data.transfer_subscription(
+            self.core_client,
+            self.trading_data_client_v2,
+        )
+
+        self.transfer_thread = threading.Thread(
+            target=self._monitor_transfer_stream,
+            args=(self.transfer_queue,),
+            daemon=True,
+        )
+        self.transfer_thread.start()
+
     def _monitor_stream(self, trade_stream: Queue[data.Order]):
         for o in trade_stream:
             with self.orders_lock:
@@ -1462,6 +1496,11 @@ class VegaService(ABC):
                     0,
                 ):
                     self._order_state_from_feed[o.market_id][o.party_id][o.id] = o
+
+    def _monitor_transfer_stream(self, transfer_stream: Queue[data.Transfer]):
+        for t in transfer_stream:
+            with self.transfers_lock:
+                self._transfer_state_from_feed.setdefault(t.party_to, {})[t.id] = t
 
     def margin_levels(
         self,

--- a/vega_sim/service.py
+++ b/vega_sim/service.py
@@ -1970,7 +1970,7 @@ class VegaService(ABC):
         wallet_name: Optional[str] = None,
         key_name: Optional[str] = None,
         direction: Optional[data_node_protos_v2.trading_data.TransferDirection] = None,
-    ):
+    ) -> List[data.Transfer]:
 
         party_id = (
             self.wallet.public_key(name=wallet_name, key_name=key_name)

--- a/vega_sim/service.py
+++ b/vega_sim/service.py
@@ -1915,3 +1915,15 @@ class VegaService(ABC):
             reference=reference,
             one_off=one_off,
         )
+
+    def list_transfers(
+        self,
+        wallet_name: str,
+        key_name: Optional[str] = None,
+        direction: Optional[data_node_protos_v2.trading_data.TransferDirection] = None,
+    ):
+        return data.list_transfers(
+            data_client=self.trading_data_client_v2,
+            party_id=self.wallet.public_key(name=wallet_name, key_name=key_name),
+            direction=direction,
+        )

--- a/vega_sim/service.py
+++ b/vega_sim/service.py
@@ -1971,6 +1971,20 @@ class VegaService(ABC):
         key_name: Optional[str] = None,
         direction: Optional[data_node_protos_v2.trading_data.TransferDirection] = None,
     ) -> List[data.Transfer]:
+        """Returns a list of processed transfers.
+
+        Args:
+            wallet_name (Optional[str], optional):
+                Name of wallet to return transfers for. Defaults to None.
+            key_name (Optional[str], optional):
+                Name of key to return transfers for. Defaults to None.
+            direction (Optional[data_node_protos_v2.trading_data.TransferDirection], optional):
+                Direction of transfers to return. Defaults to None.
+
+        Returns:
+            List[Transfer]:
+                A list of processed Transfer objects for the specified party and direction.
+        """
 
         party_id = (
             self.wallet.public_key(name=wallet_name, key_name=key_name)

--- a/vega_sim/service.py
+++ b/vega_sim/service.py
@@ -1957,12 +1957,19 @@ class VegaService(ABC):
 
     def list_transfers(
         self,
-        wallet_name: str,
+        wallet_name: Optional[str] = None,
         key_name: Optional[str] = None,
         direction: Optional[data_node_protos_v2.trading_data.TransferDirection] = None,
     ):
+
+        party_id = (
+            self.wallet.public_key(name=wallet_name, key_name=key_name)
+            if wallet_name is not None
+            else None
+        )
+
         return data.list_transfers(
             data_client=self.trading_data_client_v2,
-            party_id=self.wallet.public_key(name=wallet_name, key_name=key_name),
+            party_id=party_id,
             direction=direction,
         )


### PR DESCRIPTION
### Description
PR adds a separate monitoring stream for transfers.

Monitoring stream will be used to query transfers `to` a `party_id` (required for the hedged market maker to be able to track inbound transfers which have been accepted but the deliver time has not been reached).

### Testing

Unit tests added for new `data` and `data_raw` methods and integration tests updated for new `service` methods.

Passing all tests locally 👍 

### Breaking Changes
None

