### PR TITLE
fix: market orders price as "None"

### DIFF
--- a/tests/integration/test_trading.py
+++ b/tests/integration/test_trading.py
@@ -15,7 +15,7 @@ LIQ = WalletConfig("liq", "liq")
 PARTY_A = WalletConfig("party_a", "party_a")
 PARTY_B = WalletConfig("party_b", "party_b")
 
-
+@pytest.mark.integration
 def test_submit_market_order(vega_service_with_market: VegaServiceNull):
 
     vega = vega_service_with_market

--- a/tests/integration/test_trading.py
+++ b/tests/integration/test_trading.py
@@ -15,6 +15,7 @@ LIQ = WalletConfig("liq", "liq")
 PARTY_A = WalletConfig("party_a", "party_a")
 PARTY_B = WalletConfig("party_b", "party_b")
 
+
 @pytest.mark.integration
 def test_submit_market_order(vega_service_with_market: VegaServiceNull):
 

--- a/vega_sim/service.py
+++ b/vega_sim/service.py
@@ -665,7 +665,7 @@ class VegaService(ABC):
             time_in_force=time_in_force,
             side=side,
             volume=submit_volume,
-            price=str(submit_price),
+            price=str(submit_price) if submit_price is not None else None,
             expires_at=expires_at,
             pegged_order=vega_protos.vega.PeggedOrder(
                 reference=pegged_order.reference,
@@ -1757,7 +1757,7 @@ class VegaService(ABC):
         return trading.order_submission(
             data_client=self.trading_data_client,
             market_id=market_id,
-            price=str(price),
+            price=str(price) if price is not None else None,
             size=size,
             side=side,
             time_in_force=time_in_force,


### PR DESCRIPTION
### Description
Small fix for `submit_market_order` and `create_order_submission` where a str of `"None"` was being submitted instead of `None` for orders where no price was specified (i.e. market orders).

PR also adds an integration test for market orders (limit orders already covered through the actual market creation in the fixture).

### Testing
Test added for market orders. All tests passing locally.
