### PR TITLE
feat: configurable streaming node

### DIFF
--- a/devops/run.py
+++ b/devops/run.py
@@ -69,6 +69,7 @@ def main():
             warn_on_raw_data_access=False,
             run_with_console=args.console,
             launch_graphql=args.graphql,
+            start_order_feed=False,
         ) as vega:
 
             scenario.run_iteration(
@@ -81,6 +82,7 @@ def main():
 
         with VegaServiceNetwork(
             network=Network[args.network],
+            start_order_feed=False,
         ) as vega:
 
             scenario.run_iteration(

--- a/devops/scenario.py
+++ b/devops/scenario.py
@@ -138,6 +138,7 @@ class DevOpsScenario(Scenario):
             asset_dp=self.market_manager_args.adp,
             initial_mint=self.market_manager_args.initial_mint,
             settlement_price=self.price_process[-1],
+            tag="",
         )
 
         # Setup agent for proving a market for traders
@@ -160,6 +161,7 @@ class DevOpsScenario(Scenario):
             price_process_generator=iter(self.price_process),
             orders_from_stream=False,
             state_update_freq=10,
+            tag="",
         )
 
         # Setup agents for passing opening auction
@@ -173,7 +175,7 @@ class DevOpsScenario(Scenario):
                 initial_asset_mint=self.auction_trader_args.initial_mint,
                 initial_price=self.price_process[0],
                 side=["SIDE_BUY", "SIDE_SELL"][i],
-                tag=i,
+                tag="",
             )
             for i, party in enumerate(AUCTION_TRADER_AGENTS)
         ]
@@ -190,7 +192,7 @@ class DevOpsScenario(Scenario):
                 buy_intensity=self.random_trader_args.order_intensity,
                 sell_intensity=self.random_trader_args.order_intensity,
                 base_order_size=self.random_trader_args.order_volume,
-                tag=i,
+                tag="",
             )
             for i, party in enumerate(RANDOM_TRADER_AGENTS)
         ]
@@ -207,7 +209,7 @@ class DevOpsScenario(Scenario):
                 initial_asset_mint=self.momentum_trader_args.initial_mint,
                 order_intensity=self.momentum_trader_args.order_intensity,
                 base_order_size=self.momentum_trader_args.order_volume,
-                tag=i,
+                tag="",
             )
             for i, party in enumerate(MOMENTUM_TRADER_AGENTS)
         ]
@@ -226,7 +228,7 @@ class DevOpsScenario(Scenario):
                 sell_intensity=self.sensitive_trader_args.order_intensity[i],
                 base_order_size=self.sensitive_trader_args.order_volume[i],
                 price_half_life=self.sensitive_trader_args.price_half_life[i],
-                tag=i,
+                tag="",
             )
             for i, party in enumerate(SENSITIVE_TRADER_AGENTS)
         ]

--- a/vega_sim/api/data.py
+++ b/vega_sim/api/data.py
@@ -824,8 +824,6 @@ def order_subscription(
     order_stream = data_raw.observe_event_bus(
         data_client=data_client,
         type=[events_protos.BUS_EVENT_TYPE_ORDER],
-        market_id=market_id,
-        party_id=party_id,
     )
 
     def _order_gen(

--- a/vega_sim/api/data_raw.py
+++ b/vega_sim/api/data_raw.py
@@ -314,9 +314,14 @@ def observe_event_bus(
         Iterable[vega_protos.api.v1.core.ObserveEventBusResponse]:
             Infinite iterable of lists of events updates
     """
-    return data_client.ObserveEventBus(
-        iter([vega_protos.api.v1.core.ObserveEventBusRequest(type=type)])
-    )
+
+    request = vega_protos.api.v1.core.ObserveEventBusRequest(type=type)
+    if market_id is not None:
+        setattr(request, "market_id", market_id)
+    if party_id is not None:
+        setattr(request, "party_id", party_id)
+
+    return data_client.ObserveEventBus(iter([request]))
 
 
 def margin_levels(

--- a/vega_sim/network_service.py
+++ b/vega_sim/network_service.py
@@ -166,6 +166,7 @@ class VegaServiceNetwork(VegaService):
         network: Network,
         run_with_wallet: bool = True,
         run_with_console: bool = True,
+        start_order_feed: bool = True,
     ):
         """Method initialises the class.
 
@@ -184,6 +185,7 @@ class VegaServiceNetwork(VegaService):
         self.network = network
         self.run_with_wallet = run_with_wallet
         self.run_with_console = run_with_console
+        self._start_order_feed = start_order_feed
 
         self._wallet = None
         self._wallet_url = None
@@ -230,6 +232,9 @@ class VegaServiceNetwork(VegaService):
                 f" http://localhost:{vega_console_port}"
             )
             webbrowser.open(f"http://localhost:{vega_console_port}/", new=2)
+
+        if self._start_order_feed:
+            self.start_order_monitoring()
 
     def stop(self) -> None:
 

--- a/vega_sim/scenario/adhoc.py
+++ b/vega_sim/scenario/adhoc.py
@@ -52,6 +52,7 @@ def main():
             ),
             retain_log_files=True,
             use_full_vega_wallet=False,
+            start_order_feed=False,
         ) as vega:
             scenario.run_iteration(
                 vega=vega,
@@ -65,6 +66,7 @@ def main():
             network=Network[args.network],
             run_with_wallet=True,
             run_with_console=True,
+            start_order_feed=False,
         ) as vega:
             scenario.run_iteration(
                 vega=vega,


### PR DESCRIPTION
### Description

PR adds functionality to switch whether service listens to a stream event from a core node or a datanode.

PR also updates how `base_orders` is constructed.
- Previously all orders for all markets requested (fewer requests, faster for sims, slower for networks)
- Now only orders for specified markets and parties requested (multiple requests,  slower for sims, faster for networks)

### Testing
Passing all tests locally.

### Breaking Changes
None

### Closes
Closes #273 
