### PR TITLE
feat: add multiple lps visualisation example

### DIFF
--- a/examples/visualisations/closed_out.py
+++ b/examples/visualisations/closed_out.py
@@ -131,6 +131,7 @@ if __name__ == "__main__":
                 best_bid_id=best_bid_id,
                 price=price,
                 spread=10,
+                volume=1,
             )
             vega.wait_for_total_catchup()
             vega.wait_fn(60)

--- a/examples/visualisations/loss_socialisation.py
+++ b/examples/visualisations/loss_socialisation.py
@@ -131,6 +131,7 @@ if __name__ == "__main__":
                 best_bid_id=best_bid_id,
                 price=price,
                 spread=10,
+                volume=1,
             )
             vega.wait_for_total_catchup()
             vega.wait_fn(60)

--- a/examples/visualisations/multiple_lps.py
+++ b/examples/visualisations/multiple_lps.py
@@ -144,7 +144,7 @@ if __name__ == "__main__":
         vega.wait_for_total_catchup()
         input(
             "Pause simulation to allow UI to be inspected. "
-            + "Provision from LP_A should be deployed."
+            + "Fee should be updated to 0.01 (1.00%)"
         )
 
         # Place trades so open interest is ~400 and target stake is >20000
@@ -160,7 +160,7 @@ if __name__ == "__main__":
         vega.wait_for_total_catchup()
         input(
             "Pause simulation to allow UI to be inspected. "
-            + "Provision from LP_A and LP_B should be deployed."
+            + "Fee should be updated to 0.02 (2.00%)."
         )
 
         # Place trades so open interest is ~600 and target stake is >30000
@@ -176,5 +176,5 @@ if __name__ == "__main__":
         vega.wait_for_total_catchup()
         input(
             "Pause simulation to allow UI to be inspected. "
-            + "Provision from LP_A, LP_B, and LP_C should be deployed."
+            + "Fee should be updated to 0.03 (3.00%)"
         )

--- a/examples/visualisations/multiple_lps.py
+++ b/examples/visualisations/multiple_lps.py
@@ -129,7 +129,6 @@ if __name__ == "__main__":
             vega=vega, market_id=market_id, price=1000, spread=1, volume=10
         )
         vega.wait_fn(120)
-        input("Pause simulation to allow UI to be inspected.")
 
         # Place trades so open interest is ~200 and target stake is >10000
         utils.move_market(

--- a/examples/visualisations/multiple_lps.py
+++ b/examples/visualisations/multiple_lps.py
@@ -1,0 +1,181 @@
+import argparse
+import logging
+
+from collections import namedtuple
+
+from vega_sim.null_service import VegaServiceNull
+import examples.visualisations.utils as utils
+
+PartyConfig = namedtuple("WalletConfig", ["wallet_name", "wallet_pass", "key_name"])
+
+WALLET_NAME = "vega"
+WALLET_PASS = "pass"
+
+
+LP_A = PartyConfig(
+    wallet_name=WALLET_NAME, wallet_pass=WALLET_PASS, key_name="LP A Party"
+)
+LP_B = PartyConfig(
+    wallet_name=WALLET_NAME, wallet_pass=WALLET_PASS, key_name="LP B Party"
+)
+LP_C = PartyConfig(
+    wallet_name=WALLET_NAME, wallet_pass=WALLET_PASS, key_name="LP C Party"
+)
+
+
+TRADER_A = PartyConfig(
+    wallet_name=WALLET_NAME, wallet_pass=WALLET_PASS, key_name="Trader A Party"
+)
+TRADER_B = PartyConfig(
+    wallet_name=WALLET_NAME, wallet_pass=WALLET_PASS, key_name="Trader B Party"
+)
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--console", action="store_true")
+    parser.add_argument("--debug", action="store_true")
+    parser.add_argument("--pause", action="store_true")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.DEBUG if args.debug else logging.INFO)
+
+    with VegaServiceNull(
+        run_with_console=args.console,
+        warn_on_raw_data_access=False,
+    ) as vega:
+
+        # Create wallets for auxiliary and example specific parties
+        utils.create_auxiliary_parties(vega=vega)
+        vega.create_wallet(
+            name=LP_A.wallet_name, key_name=LP_A.key_name, passphrase=LP_A.wallet_pass
+        )
+        vega.create_wallet(
+            name=LP_B.wallet_name, key_name=LP_B.key_name, passphrase=LP_B.wallet_pass
+        )
+        vega.create_wallet(
+            name=LP_C.wallet_name, key_name=LP_C.key_name, passphrase=LP_C.wallet_pass
+        )
+
+        # Mint governance asset for auxiliary parties and create settlement asset
+        utils.mint_governance_asset(vega=vega)
+        asset_id = utils.propose_asset(vega=vega)
+
+        # Mint assets for auxiliary and example specific parties
+        utils.mint_settlement_asset(vega=vega, asset_id=asset_id)
+        vega.mint(
+            wallet_name=LP_A.wallet_name,
+            key_name=LP_A.key_name,
+            asset=asset_id,
+            amount=1e9,
+        )
+        vega.mint(
+            wallet_name=LP_B.wallet_name,
+            key_name=LP_B.key_name,
+            asset=asset_id,
+            amount=1e9,
+        )
+        vega.mint(
+            wallet_name=LP_C.wallet_name,
+            key_name=LP_C.key_name,
+            asset=asset_id,
+            amount=1e9,
+        )
+
+        # Create the market
+        market_id = utils.propose_market(vega=vega, asset_id=asset_id)
+
+        # Each LP party submits a liquidity provision at different fees
+        vega.submit_simple_liquidity(
+            wallet_name=LP_A.wallet_name,
+            key_name=LP_A.key_name,
+            market_id=market_id,
+            commitment_amount=15000,
+            fee=0.01,
+            reference_buy="PEGGED_REFERENCE_MID",
+            reference_sell="PEGGED_REFERENCE_MID",
+            delta_buy=1,
+            delta_sell=1,
+            is_amendment=False,
+        )
+        vega.submit_simple_liquidity(
+            wallet_name=LP_B.wallet_name,
+            key_name=LP_B.key_name,
+            market_id=market_id,
+            commitment_amount=15000,
+            fee=0.02,
+            reference_buy="PEGGED_REFERENCE_MID",
+            reference_sell="PEGGED_REFERENCE_MID",
+            delta_buy=2,
+            delta_sell=2,
+            is_amendment=False,
+        )
+        vega.submit_simple_liquidity(
+            wallet_name=LP_C.wallet_name,
+            key_name=LP_C.key_name,
+            market_id=market_id,
+            commitment_amount=15000,
+            fee=0.03,
+            reference_buy="PEGGED_REFERENCE_MID",
+            reference_sell="PEGGED_REFERENCE_MID",
+            delta_buy=3,
+            delta_sell=3,
+            is_amendment=False,
+        )
+
+        # Exit auction
+        best_bid_id, best_ask_id = utils.exit_auction(
+            vega=vega, market_id=market_id, price=1000, spread=1, volume=10
+        )
+        vega.wait_fn(120)
+        input("Pause simulation to allow UI to be inspected.")
+
+        # Place trades so open interest is ~200 and target stake is >10000
+        utils.move_market(
+            vega=vega,
+            market_id=market_id,
+            best_bid_id=best_bid_id,
+            best_ask_id=best_ask_id,
+            price=1000,
+            spread=1,
+            volume=200,
+        )
+        vega.wait_for_total_catchup()
+        input(
+            "Pause simulation to allow UI to be inspected. "
+            + "Provision from LP_A should be deployed."
+        )
+
+        # Place trades so open interest is ~400 and target stake is >20000
+        utils.move_market(
+            vega=vega,
+            market_id=market_id,
+            best_bid_id=best_bid_id,
+            best_ask_id=best_ask_id,
+            price=1000,
+            spread=1,
+            volume=200,
+        )
+        vega.wait_for_total_catchup()
+        input(
+            "Pause simulation to allow UI to be inspected. "
+            + "Provision from LP_A and LP_B should be deployed."
+        )
+
+        # Place trades so open interest is ~600 and target stake is >30000
+        utils.move_market(
+            vega=vega,
+            market_id=market_id,
+            best_bid_id=best_bid_id,
+            best_ask_id=best_ask_id,
+            price=1000,
+            spread=1,
+            volume=200,
+        )
+        vega.wait_for_total_catchup()
+        input(
+            "Pause simulation to allow UI to be inspected. "
+            + "Provision from LP_A, LP_B, and LP_C should be deployed."
+        )
+
+        utils.move_market()

--- a/examples/visualisations/multiple_lps.py
+++ b/examples/visualisations/multiple_lps.py
@@ -43,6 +43,7 @@ if __name__ == "__main__":
     with VegaServiceNull(
         run_with_console=args.console,
         warn_on_raw_data_access=False,
+        launch_graphql=True,
     ) as vega:
 
         # Create wallets for auxiliary and example specific parties
@@ -106,8 +107,8 @@ if __name__ == "__main__":
             fee=0.02,
             reference_buy="PEGGED_REFERENCE_MID",
             reference_sell="PEGGED_REFERENCE_MID",
-            delta_buy=2,
-            delta_sell=2,
+            delta_buy=5,
+            delta_sell=5,
             is_amendment=False,
         )
         vega.submit_simple_liquidity(
@@ -118,8 +119,8 @@ if __name__ == "__main__":
             fee=0.03,
             reference_buy="PEGGED_REFERENCE_MID",
             reference_sell="PEGGED_REFERENCE_MID",
-            delta_buy=3,
-            delta_sell=3,
+            delta_buy=10,
+            delta_sell=10,
             is_amendment=False,
         )
 
@@ -177,5 +178,3 @@ if __name__ == "__main__":
             "Pause simulation to allow UI to be inspected. "
             + "Provision from LP_A, LP_B, and LP_C should be deployed."
         )
-
-        utils.move_market()

--- a/examples/visualisations/utils.py
+++ b/examples/visualisations/utils.py
@@ -352,6 +352,7 @@ def move_market(
     best_bid_id: str,
     price: int,
     spread: float,
+    volume: float,
 ):
     """Moves market to new specified price and updates the order-book spread.
 
@@ -371,6 +372,8 @@ def move_market(
             Price to move market to.
         spread (float):
             Spread between best-ask and best-bid at new price level.
+        volume (float):
+            Volume to be traded at new price.
     """
 
     market_data = vega.market_data(market_id=market_id)
@@ -422,7 +425,7 @@ def move_market(
         time_in_force="TIME_IN_FORCE_GTC",
         order_type="TYPE_LIMIT",
         side="SIDE_BUY",
-        volume=1,
+        volume=volume,
         price=price,
     )
     vega.wait_for_total_catchup()
@@ -433,7 +436,7 @@ def move_market(
         time_in_force="TIME_IN_FORCE_GTC",
         order_type="TYPE_LIMIT",
         side="SIDE_SELL",
-        volume=1,
+        volume=volume,
         price=price,
     )
     vega.wait_for_total_catchup()

--- a/tests/integration/test_visualisations.py
+++ b/tests/integration/test_visualisations.py
@@ -15,3 +15,8 @@ def test_loss_socialisation():
 @pytest.mark.integration
 def test_margins():
     runpy.run_path("examples/visualisations/margins.py")
+
+
+@pytest.mark.integration
+def test_multiple_lps():
+    runpy.run_path("examples/visualisations/multiple_lps.py")


### PR DESCRIPTION
### Description
Adds an example which allows the console liquidity provision tab to be validated.

Example creates a market with multiple liquidity providers submitting provisions at different price levels:

- `LP_A`: `commitment=15000` and `fee 0.01`
- `LP_B`: `commitment=15000` and `fee 0.02`
- `LP_C`: `commitment=15000` and `fee 0.03`

The market then exits the opening auction with a trade where `price=1000` and `size=1`.

Traders then place orders to vary the open interest and target stake in the market:

1. `max_oi=200` and `target_stake>10000`:

- Liquidity fee should be `0.01`.
- Provision from `LP_A`, `LP_B`, and `LP_C` should be `STATUS_DEPLOYED`.
- Share split should be `33%`, `33%`, `33%` between `LP_A`, `LP_B`, and `LP_C` respectively.

2. `max_oi=400` and `target_stake>20000`:

- Liquidity fee should be `0.02`.
- Provision from `LP_A`, `LP_B`, and `LP_C` should be `STATUS_DEPLOYED`.
- Share split should be `33%`, `33%`, `33%` between `LP_A`, `LP_B`, and `LP_C` respectively.

3. `max_oi=600` and `target_stake>30000`:

- Liquidity fee should be `0.03`.
- Provision from `LP_A`, `LP_B`, and `LP_C` should be `STATUS_DEPLOYED`.
- Share split should be `33%`, `33%`, `33%` between `LP_A`, `LP_B`, and `LP_C` respectively.

### Testing
Integration test added. Passing all tests.

### Example
```
$ python -m examples.visualisations.multiple_lps --console --debug --pause
```