### PR TITLE
feat: rework tags

### DIFF
--- a/examples/agent_market/agents.py
+++ b/examples/agent_market/agents.py
@@ -88,8 +88,12 @@ class MarketMaker(StateAgentWithWallet):
         terminate_wallet_pass: str,
         price_process: List[float],
         spread: float = 2,
+        tag: str = "",
+        key_name: Optional[str] = None,
     ):
-        super().__init__(wallet_name, wallet_pass)
+        super().__init__(
+            wallet_name=wallet_name, wallet_pass=wallet_pass, key_name=key_name, tag=tag
+        )
         self.terminate_wallet_name = terminate_wallet_name
         self.terminate_wallet_pass = terminate_wallet_pass
         self.price_process = iter(price_process)

--- a/tests/integration/test_crash.py
+++ b/tests/integration/test_crash.py
@@ -40,11 +40,12 @@ def test_crash(vega_service_with_order_feed: VegaServiceNull):
 
     vega.wait_for_datanode_sync()
     # check bond and margin for all
-    for wallet_name in [f"trader_iter_pos_{i}" for i in range(2)]:
+    for key_name in [f"_iter_pos_{i}" for i in range(2)]:
         general, margin, bond = vega.party_account(
-            wallet_name=wallet_name,
+            wallet_name="trader",
             asset_id=asset_id,
             market_id=market_id,
+            key_name=key_name,
         )
         assert margin + general <= 200
         assert bond == 0

--- a/vega_sim/environment/agent.py
+++ b/vega_sim/environment/agent.py
@@ -68,7 +68,7 @@ class AgentWithWallet(Agent):
                 to value in the environment variable "VEGA_DEFAULT_KEY_NAME".
         """
         super().__init__(tag=tag)
-        self.wallet_name = wallet_name + (f"_{tag}" if tag is not None else "")
+        self.wallet_name = wallet_name
         self.wallet_pass = wallet_pass
         self.key_name = key_name
 

--- a/vega_sim/scenario/common/agents.py
+++ b/vega_sim/scenario/common/agents.py
@@ -89,14 +89,15 @@ class MarketOrderTrader(StateAgentWithWallet):
         tag: str = "",
         random_state: Optional[np.random.RandomState] = None,
         base_order_size: float = 1,
-        key_name: str = None,
+        key_name: Optional[str] = None,
         step_bias: Optional[float] = 1,
     ):
-        super().__init__(wallet_name + str(tag), wallet_pass, key_name)
+        super().__init__(
+            wallet_name=wallet_name, wallet_pass=wallet_pass, key_name=key_name, tag=tag
+        )
         self.initial_asset_mint = initial_asset_mint
         self.buy_intensity = buy_intensity
         self.sell_intensity = sell_intensity
-        self.tag = tag
         self.market_name = market_name
         self.asset_name = asset_name
         self.random_state = (
@@ -113,6 +114,10 @@ class MarketOrderTrader(StateAgentWithWallet):
     ):
         # Initialise wallet
         super().initialise(vega=vega, create_wallet=create_wallet)
+        print(self.wallet_name)
+        print(self.wallet_pass)
+        print(self.key_name)
+        print(self.tag)
         # Get market id
         self.market_id = self.vega.find_market_id(name=self.market_name)
 
@@ -199,11 +204,12 @@ class PriceSensitiveMarketOrderTrader(StateAgentWithWallet):
         base_order_size: float = 1,
         key_name: str = None,
     ):
-        super().__init__(wallet_name + str(tag), wallet_pass, key_name)
+        super().__init__(
+            wallet_name=wallet_name, wallet_pass=wallet_pass, key_name=key_name, tag=tag
+        )
         self.initial_asset_mint = initial_asset_mint
         self.buy_intensity = buy_intensity
         self.sell_intensity = sell_intensity
-        self.tag = tag
         self.market_name = market_name
         self.asset_name = asset_name
         self.random_state = (
@@ -313,13 +319,15 @@ class BackgroundMarket(StateAgentWithWallet):
         base_volume_size: float = 0.1,
         order_distribution_kappa: float = 1,
         tag: str = "",
+        key_name: Optional[str] = None,
     ):
-        super().__init__(wallet_name + tag, wallet_pass)
+        super().__init__(
+            wallet_name=wallet_name, wallet_pass=wallet_pass, key_name=key_name, tag=tag
+        )
         self.price_process = price_process
         self.initial_asset_mint = initial_asset_mint
         self.spread = spread
         self.current_step = 0
-        self.tag = tag
         self.tick_spacing = tick_spacing
         self.num_levels_per_side = num_levels_per_side
         self.base_volume_size = base_volume_size
@@ -348,6 +356,7 @@ class BackgroundMarket(StateAgentWithWallet):
                 self.wallet_name,
                 asset=asset_id,
                 amount=self.initial_asset_mint,
+                key_name=self.key_name,
             )
         self.vega.wait_fn(2)
 
@@ -496,6 +505,7 @@ class MultiRegimeBackgroundMarket(StateAgentWithWallet):
         price_process: List[float],
         market_regimes: List[MarketRegime],
         tag: str = "",
+        key_name: Optional[str] = None,
     ):
         """Generate a background market acting differently as time passes.
         Allows specification of varying numbers of non-overlapping regimes
@@ -520,11 +530,14 @@ class MultiRegimeBackgroundMarket(StateAgentWithWallet):
                     a start/end date and are interpreted as a sparse set
             tag:
                 str, a tag which will be added to the wallet name
+            key_name:
+                str, optional, The name of the key in the wallet to use
         """
-        super().__init__(wallet_name + tag, wallet_pass)
+        super().__init__(
+            wallet_name=wallet_name, wallet_pass=wallet_pass, key_name=key_name, tag=tag
+        )
         self.price_process = price_process
         self.current_step = 0
-        self.tag = tag
 
         self.market_name = market_name
         self.asset_name = asset_name
@@ -583,6 +596,7 @@ class MultiRegimeBackgroundMarket(StateAgentWithWallet):
                 self.wallet_name,
                 asset=asset_id,
                 amount=200000,
+                key_name=self.key_name,
             )
         self.vega.wait_fn(2)
 
@@ -759,11 +773,12 @@ class OpenAuctionPass(StateAgentWithWallet):
         tag: str = "",
         key_name: str = None,
     ):
-        super().__init__(wallet_name + str(tag), wallet_pass, key_name)
+        super().__init__(
+            wallet_name=wallet_name, wallet_pass=wallet_pass, key_name=key_name, tag=tag
+        )
         self.side = side
         self.initial_asset_mint = initial_asset_mint
         self.initial_price = initial_price
-        self.tag = tag
         self.market_name = market_name
         self.asset_name = asset_name
         self.opening_auction_trade_amount = opening_auction_trade_amount
@@ -830,8 +845,10 @@ class MarketManager(StateAgentWithWallet):
         key_name: str = None,
         terminate_key_name: str = None,
     ):
-        super().__init__(wallet_name + str(tag), wallet_pass, key_name)
-        self.terminate_wallet_name = terminate_wallet_name + str(tag)
+        super().__init__(
+            wallet_name=wallet_name, wallet_pass=wallet_pass, key_name=key_name, tag=tag
+        )
+        self.terminate_wallet_name = terminate_wallet_name
         self.terminate_wallet_pass = terminate_wallet_pass
         self.terminate_key_name = terminate_key_name
 
@@ -842,7 +859,6 @@ class MarketManager(StateAgentWithWallet):
 
         self.current_step = 0
 
-        self.tag = tag
         self.initial_mint = (
             initial_mint
             if initial_mint is not None
@@ -983,9 +999,7 @@ class ShapedMarketMaker(StateAgentWithWallet):
         max_order_size: float = 10000,
     ):
         super().__init__(
-            wallet_name + str(tag),
-            wallet_pass,
-            key_name,
+            wallet_name=wallet_name, wallet_pass=wallet_pass, key_name=key_name, tag=tag
         )
         self.price_process_generator = price_process_generator
         self.commitment_amount = commitment_amount
@@ -1000,8 +1014,6 @@ class ShapedMarketMaker(StateAgentWithWallet):
         self.current_step = 0
         self.curr_price = None
         self.prev_price = None
-
-        self.tag = tag
 
         self.market_name = f"ETH:USD_{self.tag}" if market_name is None else market_name
         self.asset_name = f"tDAI{self.tag}" if asset_name is None else asset_name
@@ -1854,7 +1866,9 @@ class LimitOrderTrader(StateAgentWithWallet):
                 Standard deviation of the log-normal distribution.
         """
 
-        super().__init__(wallet_name + str(tag), wallet_pass, key_name)
+        super().__init__(
+            wallet_name=wallet_name, wallet_pass=wallet_pass, key_name=key_name, tag=tag
+        )
 
         self.current_step = 0
 
@@ -1865,7 +1879,6 @@ class LimitOrderTrader(StateAgentWithWallet):
         self.sell_intensity = sell_intensity
         self.buy_volume = buy_volume
         self.sell_volume = sell_volume
-        self.tag = tag
         self.submit_bias = submit_bias
         self.cancel_bias = cancel_bias
         self.random_state = (
@@ -2068,12 +2081,13 @@ class InformedTrader(StateAgentWithWallet):
             random_state (Optional[np.random.RandomState], optional):
                 RandomState object used to generate randomness. Defaults to None.
         """
-        super().__init__(wallet_name + str(tag), wallet_pass)
+        super().__init__(
+            wallet_name=wallet_name, wallet_pass=wallet_pass, key_name=key_name, tag=tag
+        )
         self.initial_asset_mint = initial_asset_mint
         self.price_process = price_process
         self.current_step = 0
         self.sim_length = len(price_process)
-        self.tag = tag
         self.proportion_taken = proportion_taken
         self.market_name = f"ETH:USD_{self.tag}" if market_name is None else market_name
         self.asset_name = f"tDAI_{self.tag}" if asset_name is None else asset_name
@@ -2237,8 +2251,11 @@ class LiquidityProvider(StateAgentWithWallet):
         offset: float = 0.01,
         fee: float = 0.001,
         tag: str = "",
+        key_name: Optional[str] = None,
     ):
-        super().__init__(wallet_name + str(tag), wallet_pass)
+        super().__init__(
+            wallet_name=wallet_name, wallet_pass=wallet_pass, key_name=key_name, tag=tag
+        )
 
         self.market_name = market_name
         self.asset_name = asset_name
@@ -2266,6 +2283,7 @@ class LiquidityProvider(StateAgentWithWallet):
                 self.wallet_name,
                 asset=self.asset_id,
                 amount=self.initial_asset_mint,
+                key_name=self.key_name,
             )
             self.vega.wait_fn(2)
 
@@ -2314,13 +2332,14 @@ class MomentumTrader(StateAgentWithWallet):
         tag: str = "",
         key_name: str = None,
     ):
-        super().__init__(wallet_name, wallet_pass, key_name)
+        super().__init__(
+            wallet_name=wallet_name, wallet_pass=wallet_pass, key_name=key_name, tag=tag
+        )
         self.market_name = market_name
         self.asset_name = asset_name
         self.initial_asset_mint = initial_asset_mint
         self.order_intensity = order_intensity
         self.base_order_size = base_order_size
-        self.tag = tag
         self.trading_proportion = trading_proportion
         self.random_state = (
             random_state if random_state is not None else np.random.RandomState()

--- a/vega_sim/scenario/common/agents.py
+++ b/vega_sim/scenario/common/agents.py
@@ -114,10 +114,6 @@ class MarketOrderTrader(StateAgentWithWallet):
     ):
         # Initialise wallet
         super().initialise(vega=vega, create_wallet=create_wallet)
-        print(self.wallet_name)
-        print(self.wallet_pass)
-        print(self.key_name)
-        print(self.tag)
         # Get market id
         self.market_id = self.vega.find_market_id(name=self.market_name)
 

--- a/vega_sim/scenario/configurable_market/agents.py
+++ b/vega_sim/scenario/configurable_market/agents.py
@@ -45,6 +45,7 @@ class ConfigurableMarketManager(StateAgentWithWallet):
             wallet_name=proposal_wallet_name,
             wallet_pass=proposal_wallet_pass,
             key_name=proposal_key_name,
+            tag=tag,
         )
 
         self.termination_wallet_name = termination_wallet_name
@@ -63,7 +64,6 @@ class ConfigurableMarketManager(StateAgentWithWallet):
             market_config if market_config is not None else MarketConfig()
         )
 
-        self.tag = tag
         self.settlement_price = settlement_price
 
     def initialise(

--- a/vega_sim/scenario/ideal_market_maker/agents.py
+++ b/vega_sim/scenario/ideal_market_maker/agents.py
@@ -62,8 +62,11 @@ class OptimalMarketMaker(StateAgentWithWallet):
         settlement_price: Optional[float] = None,
         tag: str = "",
         random_state: Optional[np.random.RandomState] = None,
+        key_name: Optional[str] = None,
     ):
-        super().__init__(wallet_name + tag, wallet_pass)
+        super().__init__(
+            wallet_name=wallet_name, wallet_pass=wallet_pass, key_name=key_name, tag=tag
+        )
         self.terminate_wallet_name = terminate_wallet_name + tag
         self.terminate_wallet_pass = terminate_wallet_pass
 
@@ -86,7 +89,6 @@ class OptimalMarketMaker(StateAgentWithWallet):
         self.settlement_price = (
             self.price_process[-1] if settlement_price is None else settlement_price
         )
-        self.tag = tag
         self.market_name = f"ETH:USD_{self.tag}" if market_name is None else market_name
         self.asset_name = f"tDAI_{self.tag}" if asset_name is None else asset_name
         self.random_state = (
@@ -140,6 +142,7 @@ class OptimalMarketMaker(StateAgentWithWallet):
             self.wallet_name,
             asset="VOTE",
             amount=1e4,
+            key_name=self.key_name,
         )
         self.vega.wait_fn(5)
 
@@ -150,6 +153,7 @@ class OptimalMarketMaker(StateAgentWithWallet):
             symbol=self.asset_name,
             decimals=self.adp,
             max_faucet_amount=1e20,
+            key_name=self.key_name,
         )
         self.vega.wait_fn(5)
         self.vega.wait_for_total_catchup()
@@ -160,6 +164,7 @@ class OptimalMarketMaker(StateAgentWithWallet):
             self.wallet_name,
             asset=self.asset_id,
             amount=self.initial_asset_mint,
+            key_name=self.key_name,
         )
         self.vega.wait_for_total_catchup()
 
@@ -172,6 +177,7 @@ class OptimalMarketMaker(StateAgentWithWallet):
             market_decimals=self.mdp,
             position_decimals=self.market_position_decimal,
             future_asset=self.asset_name,
+            key_name=self.key_name,
         )
         self.vega.wait_for_total_catchup()
 
@@ -186,6 +192,7 @@ class OptimalMarketMaker(StateAgentWithWallet):
             buy_specs=[("PEGGED_REFERENCE_MID", 0.1, 1)],
             sell_specs=[("PEGGED_REFERENCE_MID", 0.1, 1)],
             is_amendment=False,
+            key_name=self.key_name,
         )
         self.bid_depth, self.ask_depth = self.OptimalStrategy(0)
 
@@ -275,12 +282,15 @@ class OptimalMarketMaker(StateAgentWithWallet):
                 delta_buy=temp_depth,
                 delta_sell=temp_depth,
                 is_amendment=True,
+                key_name=self.key_name,
             )
 
     def step(self, vega_state: VegaState):
         # Each step, MM posts optimal bid/ask depths
         position = self.vega.positions_by_market(
-            wallet_name=self.wallet_name, market_id=self.market_id
+            wallet_name=self.wallet_name,
+            market_id=self.market_id,
+            key_name=self.key_name,
         )
 
         current_position = int(position[0].open_volume) if position else 0
@@ -304,6 +314,7 @@ class OptimalMarketMaker(StateAgentWithWallet):
             delta_buy=self.bid_depth,
             delta_sell=self.ask_depth,
             is_amendment=True,
+            key_name=self.key_name,
         )
         self.current_step += 1
 
@@ -321,12 +332,14 @@ class MarketOrderTrader(StateAgentWithWallet):
         num_buy_market_order: int = None,
         num_sell_market_order: int = None,
         tag: str = "",
+        key_name: Optional[str] = None,
     ):
-        super().__init__(wallet_name + str(tag), wallet_pass)
+        super().__init__(
+            wallet_name=wallet_name, wallet_pass=wallet_pass, key_name=key_name, tag=tag
+        )
         self.initial_asset_mint = initial_asset_mint
         self.num_buyMO = num_buy_market_order
         self.num_sellMO = num_sell_market_order
-        self.tag = tag
         self.market_name = f"ETH:USD_{self.tag}" if market_name is None else market_name
         self.asset_name = f"tDAI_{self.tag}" if asset_name is None else asset_name
 
@@ -344,6 +357,7 @@ class MarketOrderTrader(StateAgentWithWallet):
             self.wallet_name,
             asset=tDAI_id,
             amount=self.initial_asset_mint,
+            key_name=self.key_name,
         )
         self.vega.wait_fn(2)
 
@@ -356,6 +370,7 @@ class MarketOrderTrader(StateAgentWithWallet):
                 volume=self.num_buyMO,
                 wait=False,
                 fill_or_kill=False,
+                key_name=self.key_name,
             )
 
     def step_sell(self, vega_state: VegaState):
@@ -367,6 +382,7 @@ class MarketOrderTrader(StateAgentWithWallet):
                 volume=self.num_sellMO,
                 wait=False,
                 fill_or_kill=False,
+                key_name=self.key_name,
             )
 
 
@@ -388,8 +404,11 @@ class LimitOrderTrader(StateAgentWithWallet):
         market_name: str = None,
         asset_name: str = None,
         tag: str = "",
+        key_name: Optional[str] = None,
     ):
-        super().__init__(wallet_name + tag, wallet_pass)
+        super().__init__(
+            wallet_name=wallet_name, wallet_pass=wallet_pass, key_name=key_name, tag=tag
+        )
         self.num_post_at_bid = num_post_at_bid
         self.num_post_at_ask = num_post_at_ask
         self.price_process = price_process
@@ -399,7 +418,6 @@ class LimitOrderTrader(StateAgentWithWallet):
         self.adp = asset_decimal
         self.initial_asset_mint = initial_asset_mint
         self.current_step = 0
-        self.tag = tag
         self.market_name = f"ETH:USD_{self.tag}" if market_name is None else market_name
         self.asset_name = f"tDAI_{self.tag}" if asset_name is None else asset_name
 
@@ -416,6 +434,7 @@ class LimitOrderTrader(StateAgentWithWallet):
             self.wallet_name,
             asset=tDAI_id,
             amount=self.initial_asset_mint,
+            key_name=self.key_name,
         )
         self.vega.wait_fn(2)
 
@@ -428,6 +447,7 @@ class LimitOrderTrader(StateAgentWithWallet):
             volume=1,
             price=round(self.initial_price - self.spread, self.mdp),
             wait=True,
+            key_name=self.key_name,
         )
 
         self.sell_order_id = self.vega.submit_order(
@@ -439,6 +459,7 @@ class LimitOrderTrader(StateAgentWithWallet):
             volume=1,
             price=round(self.initial_price + self.spread, self.mdp),
             wait=True,
+            key_name=self.key_name,
         )
 
     def step_amendprice(self, vega_state: VegaState):
@@ -462,6 +483,7 @@ class LimitOrderTrader(StateAgentWithWallet):
                     new_price - self.spread / 2,
                     self.mdp,
                 ),
+                key_name=self.key_name,
             )
 
         self.vega.amend_order(
@@ -472,6 +494,7 @@ class LimitOrderTrader(StateAgentWithWallet):
                 new_price + self.spread / 2,
                 self.mdp,
             ),
+            key_name=self.key_name,
         )
 
         if first_side == vega_protos.SIDE_SELL:
@@ -483,6 +506,7 @@ class LimitOrderTrader(StateAgentWithWallet):
                     new_price - self.spread / 2,
                     self.mdp,
                 ),
+                key_name=self.key_name,
             )
 
     def step_limitorders(self, vega_state: VegaState):
@@ -498,6 +522,7 @@ class LimitOrderTrader(StateAgentWithWallet):
                 volume=self.num_post_at_bid - 1,
                 price=self.price_process[self.current_step] - random_delta,
                 wait=False,
+                key_name=self.key_name,
             )
 
         if self.num_post_at_ask > 1:
@@ -512,6 +537,7 @@ class LimitOrderTrader(StateAgentWithWallet):
                 volume=self.num_post_at_ask - 1,
                 price=self.price_process[self.current_step] + random_delta,
                 wait=False,
+                key_name=self.key_name,
             )
 
     def step_limitorderask(self, vega_state: VegaState):
@@ -524,6 +550,7 @@ class LimitOrderTrader(StateAgentWithWallet):
             volume=1,
             price=round(self.price_process[self.current_step] + self.spread, self.mdp),
             wait=True,
+            key_name=self.key_name,
         )
 
     def step_limitorderbid(self, vega_state: VegaState):
@@ -536,6 +563,7 @@ class LimitOrderTrader(StateAgentWithWallet):
             volume=1,
             price=round(self.price_process[self.current_step] - self.spread, self.mdp),
             wait=True,
+            key_name=self.key_name,
         )
 
         self.current_step += 1
@@ -554,12 +582,14 @@ class OpenAuctionPass(StateAgentWithWallet):
         initial_asset_mint: float = 1e8,
         initial_price: float = 0.3,
         tag: str = "",
+        key_name: Optional[str] = None,
     ):
-        super().__init__(wallet_name + tag, wallet_pass)
+        super().__init__(
+            wallet_name=wallet_name, wallet_pass=wallet_pass, key_name=key_name, tag=tag
+        )
         self.side = side
         self.initial_price = initial_price
         self.initial_asset_mint = initial_asset_mint
-        self.tag = tag
         self.market_name = f"ETH:USD_{self.tag}" if market_name is None else market_name
         self.asset_name = f"tDAI_{self.tag}" if asset_name is None else asset_name
 
@@ -576,6 +606,7 @@ class OpenAuctionPass(StateAgentWithWallet):
             self.wallet_name,
             asset=tDAI_id,
             amount=self.initial_asset_mint,
+            key_name=self.key_name,
         )
         self.vega.wait_fn(2)
 
@@ -587,6 +618,7 @@ class OpenAuctionPass(StateAgentWithWallet):
             side=self.side,
             volume=1,
             price=self.initial_price,
+            key_name=self.key_name,
         )
 
     def step(self, vega_state: VegaState):
@@ -614,8 +646,11 @@ class OptimalLiquidityProvider(StateAgentWithWallet):
         commitamount: float = 100000,
         lp_fee: float = 0.001,
         tag: str = "",
+        key_name: Optional[str] = None,
     ):
-        super().__init__(wallet_name + tag, wallet_pass)
+        super().__init__(
+            wallet_name=wallet_name, wallet_pass=wallet_pass, key_name=key_name, tag=tag
+        )
         self.current_step = 0
         self.initial_asset_mint = initial_asset_mint
         self.entry_step = entry_step
@@ -628,7 +663,6 @@ class OptimalLiquidityProvider(StateAgentWithWallet):
         self.q_lower = inventory_lower_boundary
         self.alpha = terminal_penalty_parameter
         self.phi = running_penalty_parameter
-        self.tag = tag
         self.market_name = f"ETH:USD_{self.tag}" if market_name is None else market_name
         self.asset_name = f"tDAI_{self.tag}" if asset_name is None else asset_name
         self.long_horizon_estimate = num_steps >= 200
@@ -647,6 +681,7 @@ class OptimalLiquidityProvider(StateAgentWithWallet):
             self.wallet_name,
             asset=tDAI_id,
             amount=self.initial_asset_mint,
+            key_name=self.key_name,
         )
         # Get asset id
         self.asset_id = self.vega.find_asset_id(symbol=self.asset_name)
@@ -655,6 +690,7 @@ class OptimalLiquidityProvider(StateAgentWithWallet):
             self.wallet_name,
             asset=self.asset_id,
             amount=self.initial_asset_mint,
+            key_name=self.key_name,
         )
         self.vega.wait_for_total_catchup()
 
@@ -737,12 +773,15 @@ class OptimalLiquidityProvider(StateAgentWithWallet):
                 delta_buy=self.bid_depth,
                 delta_sell=self.ask_depth,
                 is_amendment=False,
+                key_name=self.key_name,
             )
             self.current_step += 1
             return
 
         position = self.vega.positions_by_market(
-            wallet_name=self.wallet_name, market_id=self.market_id
+            wallet_name=self.wallet_name,
+            market_id=self.market_id,
+            key_name=self.key_name,
         )
 
         current_position = int(position[0].open_volume) if position else 0
@@ -758,6 +797,7 @@ class OptimalLiquidityProvider(StateAgentWithWallet):
             delta_buy=self.bid_depth,
             delta_sell=self.ask_depth,
             is_amendment=True,
+            key_name=self.key_name,
         )
 
         self.current_step += 1
@@ -776,13 +816,15 @@ class InformedTrader(StateAgentWithWallet):
         initial_asset_mint: float = 1e8,
         proportion_taken: float = 0.8,
         tag: str = "",
+        key_name: Optional[str] = None,
     ):
-        super().__init__(wallet_name + str(tag), wallet_pass)
+        super().__init__(
+            wallet_name=wallet_name, wallet_pass=wallet_pass, key_name=key_name, tag=tag
+        )
         self.initial_asset_mint = initial_asset_mint
         self.price_process = price_process
         self.current_step = 0
         self.sim_length = len(price_process)
-        self.tag = tag
         self.proportion_taken = proportion_taken
         self.market_name = f"ETH:USD_{self.tag}" if market_name is None else market_name
         self.asset_name = f"tDAI_{self.tag}" if asset_name is None else asset_name
@@ -801,6 +843,7 @@ class InformedTrader(StateAgentWithWallet):
             self.wallet_name,
             asset=tDAI_id,
             amount=self.initial_asset_mint,
+            key_name=self.key_name,
         )
 
         self.pdp = self.vega._market_pos_decimals.get(self.market_id, {})
@@ -808,7 +851,9 @@ class InformedTrader(StateAgentWithWallet):
 
     def step(self, vega_state: VegaState):
         position = self.vega.positions_by_market(
-            wallet_name=self.wallet_name, market_id=self.market_id
+            wallet_name=self.wallet_name,
+            market_id=self.market_id,
+            key_name=self.key_name,
         )
         current_position = int(position[0].open_volume) if position else 0
         trade_side = (
@@ -824,6 +869,7 @@ class InformedTrader(StateAgentWithWallet):
                 volume=current_position,
                 wait=True,
                 fill_or_kill=False,
+                key_name=self.key_name,
             )
 
         order_book = self.vega.market_depth(market_id=self.market_id)
@@ -854,4 +900,5 @@ class InformedTrader(StateAgentWithWallet):
                 volume=volume,
                 wait=False,
                 fill_or_kill=False,
+                key_name=self.key_name,
             )

--- a/vega_sim/scenario/market_crash/scenario.py
+++ b/vega_sim/scenario/market_crash/scenario.py
@@ -161,6 +161,7 @@ class MarketCrash(Scenario):
                     buy_intensity=self.noise_buy_intensity,
                     sell_intensity=self.noise_sell_intensity,
                     random_state=random_state,
+                    key_name=f"{tag}_noise_{i}",
                 )
             )
         for i in range(self.num_position_traders):
@@ -175,6 +176,7 @@ class MarketCrash(Scenario):
                     buy_intensity=self.position_taker_buy_intensity,
                     sell_intensity=self.position_taker_sell_intensity,
                     random_state=random_state,
+                    key_name=f"{tag}_pos_{i}",
                 )
             )
 


### PR DESCRIPTION
### Description
Currently the `tag` attribute of an agent is appended to the specified `wallet_name` when creating a wallet for an agent.
As the new scenario setup requires agents to have a unique `name` (`BASE_NAME` + `tag`), the above behaviour results in every agent having a unique wallet which is a bit clunky when debugging using console. Specifying no `tag` results in agents being overwritten when added to the scenario `agents` dictionary.

PR removes above behaviour so the specified `tag` is not appended to the `wallet_name` when creating a wallet.

As part of the PR all existing agents have been standardised to have `key_name` and `tag` arguments (see breaking changes).

### Testing
Passing all tests locally.

### Breaking Changes

Previously for some agent types, specifying a `tag` would create a unique wallet. All agents have been standardised so this behaviour no longer exists. Specifying a `tag` will now only modify the key for the instance of the agent in the `agents` dictionary.

To create a unique wallet or key for an agent, specify a unique `key_name` for the specified `wallet_name`.

