### PR TITLE
feat: get_liquidity_fee_shares method

### DIFF
--- a/vega_sim/scenario/common/agents.py
+++ b/vega_sim/scenario/common/agents.py
@@ -1650,7 +1650,7 @@ class HedgedMarketMaker(ExponentialShapedMarketMaker):
             key_name=self.key_name,
         )
 
-        int_fee = (self.int_mkr_fee + self.int_liq_fee) * fee_share
+        int_fee = self.int_mkr_fee + self.int_liq_fee * fee_share
         ext_fee = self.ext_mkr_fee + self.ext_liq_fee + self.ext_inf_fee
 
         required_bid_price = (

--- a/vega_sim/scenario/common/agents.py
+++ b/vega_sim/scenario/common/agents.py
@@ -1083,6 +1083,9 @@ class ShapedMarketMaker(StateAgentWithWallet):
         self.bid_depth, self.ask_depth = self.best_price_offset_fn(
             current_position, self.current_step
         )
+        if (self.bid_depth is None) or (self.ask_depth is None):
+            return
+
         new_buy_shape, new_sell_shape = self.shape_fn(self.bid_depth, self.ask_depth)
         scaled_buy_shape, scaled_sell_shape = self._scale_orders(
             buy_shape=new_buy_shape, sell_shape=new_sell_shape
@@ -1637,6 +1640,9 @@ class HedgedMarketMaker(ExponentialShapedMarketMaker):
         ext_best_bid, ext_best_ask = self.vega.best_prices(
             market_id=self.external_market_id
         )
+
+        if (ext_best_bid == 0) or (ext_best_ask == 0):
+            return None, None
 
         fee_share = self.vega.get_liquidity_fee_shares(
             market_id=self.market_id,

--- a/vega_sim/scenario/common/agents.py
+++ b/vega_sim/scenario/common/agents.py
@@ -1630,7 +1630,13 @@ class HedgedMarketMaker(ExponentialShapedMarketMaker):
             market_id=self.external_market_id
         )
 
-        int_fee = self.int_mkr_fee + self.int_liq_fee
+        fee_share = self.vega.get_liquidity_fee_shares(
+            market_id=self.market_id,
+            wallet_name=self.wallet_name,
+            key_name=self.key_name,
+        )
+
+        int_fee = (self.int_mkr_fee + self.int_liq_fee) * fee_share
         ext_fee = self.ext_mkr_fee + self.ext_liq_fee + self.ext_inf_fee
 
         required_bid_price = (

--- a/vega_sim/scenario/hedged_market_maker/scenario.py
+++ b/vega_sim/scenario/hedged_market_maker/scenario.py
@@ -146,8 +146,6 @@ class HedgedMarket(Scenario):
             Number of transactions allowed per block. Defaults to 1000.
         state_extraction_fn (Optional[ Callable[[VegaServiceNull, List[Agent]], Any] ], optional):
             Defines which states to extract and record. Defaults to None.
-        state_extraction_freq (int, optional):
-            How often to run the state_extraction_fn. Defaults to 1.
         pause_every_n_steps (Optional[int], optional):
             Number of steps to simulate before pausing the simulation. Defaults to None.
     """
@@ -185,9 +183,10 @@ class HedgedMarket(Scenario):
         state_extraction_fn: Optional[
             Callable[[VegaServiceNull, List[Agent]], Any]
         ] = None,
-        state_extraction_freq: int = 1,
         pause_every_n_steps: Optional[int] = None,
     ):
+        super().__init__(state_extraction_fn=state_extraction_fn)
+
         # Simulation properties
         self.num_steps = num_steps
         self.step_length_seconds = step_length_seconds
@@ -196,8 +195,6 @@ class HedgedMarket(Scenario):
         self.initial_price = initial_price
         self.random_agent_ordering = random_agent_ordering
         self.transactions_per_block = transactions_per_block
-        self.state_extraction_fn = state_extraction_fn
-        self.state_extraction_freq = state_extraction_freq
         self.pause_every_n_steps = pause_every_n_steps
 
         # Asset properties
@@ -272,6 +269,7 @@ class HedgedMarket(Scenario):
             market_position_decimal=self.int_pdp,
             market_name=self.int_name,
             settlement_price=price_process[-1],
+            tag="internal",
         )
 
         ext_market_manager = MarketManager(
@@ -287,6 +285,7 @@ class HedgedMarket(Scenario):
             market_position_decimal=self.ext_pdp,
             market_name=self.ext_name,
             settlement_price=price_process[-1],
+            tag="external",
         )
 
         int_market_maker = HedgedMarketMaker(
@@ -315,6 +314,7 @@ class HedgedMarket(Scenario):
             external_market_name=self.ext_name,
             internal_delay=self.int_lock,
             external_delay=self.ext_lock,
+            tag="internal",
         )
 
         ext_market_maker = ExponentialShapedMarketMaker(
@@ -337,6 +337,7 @@ class HedgedMarket(Scenario):
             inventory_lower_boundary=-30,
             state_update_freq=60,
             fee_amount=1e-03,
+            tag="external",
         )
 
         int_auction_pass_bid = OpenAuctionPass(
@@ -349,6 +350,7 @@ class HedgedMarket(Scenario):
             market_name=self.int_name,
             asset_name=self.asset_name,
             opening_auction_trade_amount=self.int_pdp,
+            tag="internal_bid",
         )
         int_auction_pass_ask = OpenAuctionPass(
             wallet_name=AUCTION_PASS_ASK.wallet_name,
@@ -360,6 +362,7 @@ class HedgedMarket(Scenario):
             market_name=self.int_name,
             asset_name=self.asset_name,
             opening_auction_trade_amount=self.int_pdp,
+            tag="internal_ask",
         )
         ext_auction_pass_bid = OpenAuctionPass(
             wallet_name=AUCTION_PASS_BID.wallet_name,
@@ -371,6 +374,7 @@ class HedgedMarket(Scenario):
             market_name=self.ext_name,
             asset_name=self.asset_name,
             opening_auction_trade_amount=self.ext_pdp,
+            tag="external_bid",
         )
         ext_auction_pass_ask = OpenAuctionPass(
             wallet_name=AUCTION_PASS_ASK.wallet_name,
@@ -382,6 +386,7 @@ class HedgedMarket(Scenario):
             market_name=self.ext_name,
             asset_name=self.asset_name,
             opening_auction_trade_amount=self.ext_pdp,
+            tag="external_bid",
         )
 
         int_random_trader = MarketOrderTrader(
@@ -394,6 +399,7 @@ class HedgedMarket(Scenario):
             buy_intensity=1 * 10 ** (self.int_pdp),
             sell_intensity=1 * 10 ** (self.int_pdp),
             base_order_size=1 * 10 ** -(self.int_pdp),
+            tag="internal",
         )
         ext_random_trader = MarketOrderTrader(
             wallet_name=EXT_RANDOM_TRADER.wallet_name,
@@ -405,6 +411,7 @@ class HedgedMarket(Scenario):
             buy_intensity=1 * 10 ** (self.ext_pdp),
             sell_intensity=1 * 10 ** (self.ext_pdp),
             base_order_size=1 * 10 ** -(self.ext_pdp),
+            tag="external",
         )
 
         int_informed_trader = InformedTrader(
@@ -448,9 +455,7 @@ class HedgedMarket(Scenario):
             random_agent_ordering=self.random_agent_ordering,
             transactions_per_block=self.transactions_per_block,
             vega_service=vega,
-            state_extraction_freq=self.state_extraction_freq,
             step_length_seconds=self.step_length_seconds,
             block_length_seconds=self.block_length_seconds,
-            state_extraction_fn=self.state_extraction_fn,
             pause_every_n_steps=self.pause_every_n_steps,
         )

--- a/vega_sim/service.py
+++ b/vega_sim/service.py
@@ -2058,3 +2058,23 @@ class VegaService(ABC):
             party_id=party_id,
             direction=direction,
         )
+
+    def get_liquidity_fee_shares(
+        self, market_id: str, wallet_name: str, key_name: Optional[str] = None
+    ) -> Union[Dict, float]:
+        """Gets the current liquidity fee share for each party or a specified party.
+
+        Args:
+            market_id (str):
+                Id of market.
+            wallet_name (str):
+                Name of wallet to get public key from.
+            key_name (Optional[str], optional):
+                Name of specific key in wallet to get public key for. Defaults to None.
+        """
+
+        return data.get_liquidity_fee_shares(
+            data_client=self.trading_data_client_v2,
+            market_id=market_id,
+            party_id=self.wallet.public_key(name=wallet_name, key_name=self.key_name),
+        )

--- a/vega_sim/service.py
+++ b/vega_sim/service.py
@@ -2088,5 +2088,5 @@ class VegaService(ABC):
         return data.get_liquidity_fee_shares(
             data_client=self.trading_data_client_v2,
             market_id=market_id,
-            party_id=self.wallet.public_key(name=wallet_name, key_name=self.key_name),
+            party_id=self.wallet.public_key(name=wallet_name, key_name=key_name),
         )

--- a/vega_sim/service.py
+++ b/vega_sim/service.py
@@ -2072,14 +2072,17 @@ class VegaService(ABC):
         )
 
     def get_liquidity_fee_shares(
-        self, market_id: str, wallet_name: str, key_name: Optional[str] = None
+        self,
+        market_id: str,
+        wallet_name: Optional[str] = None,
+        key_name: Optional[str] = None,
     ) -> Union[Dict, float]:
         """Gets the current liquidity fee share for each party or a specified party.
 
         Args:
             market_id (str):
                 Id of market.
-            wallet_name (str):
+            wallet_name (Optional[str] = None):
                 Name of wallet to get public key from.
             key_name (Optional[str], optional):
                 Name of specific key in wallet to get public key for. Defaults to None.
@@ -2088,5 +2091,9 @@ class VegaService(ABC):
         return data.get_liquidity_fee_shares(
             data_client=self.trading_data_client_v2,
             market_id=market_id,
-            party_id=self.wallet.public_key(name=wallet_name, key_name=key_name),
+            party_id=(
+                self.wallet.public_key(name=wallet_name, key_name=key_name)
+                if wallet_name is not None
+                else None
+            ),
         )


### PR DESCRIPTION
### Description
Adds a service method for getting a parties current share of the liquidity fees. New method used in `HedgedMarketMarket` agent to cover the scenario where it is not the only LP.

Also adds fixes to the `HedgedMarketMaker` agent and `HedgedMarket` scenario for changes from #291.

### Examples
```
$ python -m vega_sim.scenario.adhoc -s hedged_market --console --debug
```
### Testing
Passing all tests locally.

### Breaking Changes
None.

### Closes
Closes #286 