### PR TITLE
feat: Specify number of pagination records to avoid datanode issue

### DIFF
--- a/vega_sim/api/data_raw.py
+++ b/vega_sim/api/data_raw.py
@@ -20,7 +20,9 @@ def unroll_v2_pagination(
     request_func: Callable[[S], T],
     extraction_func: Callable[[S], List[U]],
 ) -> List[T]:
-    base_request.pagination.CopyFrom(data_node_protos_v2.trading_data.Pagination())
+    base_request.pagination.CopyFrom(
+        data_node_protos_v2.trading_data.Pagination(first=1000)
+    )
     response = request_func(base_request)
     full_list = extraction_func(response)
     while response.page_info.has_next_page:


### PR DESCRIPTION
### Description
<!---
What is the change?
--->
Specify a number of records to receive from datanode when pagination is required. This works around an issue where if this is unspecified then the `after` flag is ignored and so one ends up in an infinite loop.

### Testing
<!---
How has the change been tested? Were new unit/integration tests added and do current ones cover?
--->
Tested with code which used to break (RL script) and now completes successfully locally

### Breaking Changes
<!---
Are any of the changes in this PR breaking/requiring of a change in workflow?
--->
None, number of records requested is already the default, just needs manually specifying

### Closes
<!---
Does this close any issues?
--->
