### PR TITLE
feat: generalise positions by market

### DIFF
--- a/tests/integration/test_trading.py
+++ b/tests/integration/test_trading.py
@@ -46,12 +46,12 @@ def test_submit_market_order(vega_service_with_market: VegaServiceNull):
     vega.wait_fn(1)
     vega.wait_for_total_catchup()
 
-    positions_pb_t1 = vega.positions_by_market(
+    position_pb_t1 = vega.positions_by_market(
         wallet_name=PARTY_A.name,
         market_id=market_id,
     )
 
-    assert positions_pb_t1[0].open_volume == 1
+    assert position_pb_t1.open_volume == 1
 
 
 @pytest.mark.integration

--- a/tests/vega_sim/api/test_data.py
+++ b/tests/vega_sim/api/test_data.py
@@ -20,7 +20,7 @@ from vega_sim.api.data import (
     Transfer,
     OrdersBySide,
     Trade,
-    asset_decimals,
+    get_asset_decimals,
     best_prices,
     price_bounds,
     find_asset_id,
@@ -105,7 +105,7 @@ def test_party_account(trading_data_v2_servicer_and_port):
 
     assert res == PartyMarketAccount(52.35, 64.23, 10.51)
 
-    with patch("vega_sim.api.data.asset_decimals", lambda asset_id, data_client: 2):
+    with patch("vega_sim.api.data.get_asset_decimals", lambda asset_id, data_client: 2):
         res2 = party_account(
             "PUB_KEY",
             asset_id="a1",
@@ -199,7 +199,7 @@ def test_asset_decimals(mkt_info_mock):
     asset_mock.details.decimals = 3
     mkt_info_mock.return_value = asset_mock
 
-    assert asset_decimals("ASSET", None) == 3
+    assert get_asset_decimals("ASSET", None) == 3
 
 
 @patch("vega_sim.api.data_raw.market_data")
@@ -646,7 +646,7 @@ def test_order_subscription(mkt_price_mock, mkt_pos_mock, core_servicer_and_port
         assert order.id == next(queue).id
 
 
-@patch("vega_sim.api.data.asset_decimals")
+@patch("vega_sim.api.get_asset_decimals")
 def test_transfer_subscription(mk_asset_decimals, core_servicer_and_port):
     mk_asset_decimals.return_value = 1
     transfers = [
@@ -771,7 +771,7 @@ def test_transfer_subscription(mk_asset_decimals, core_servicer_and_port):
         assert transfer.id == next(queue).id
 
 
-@patch("vega_sim.api.data.asset_decimals")
+@patch("vega_sim.api.get_asset_decimals")
 def test_market_limits(mk_asset_decimals, trading_data_v2_servicer_and_port):
     expected = [
         MarginLevels(
@@ -829,7 +829,7 @@ def test_market_limits(mk_asset_decimals, trading_data_v2_servicer_and_port):
     assert res == expected
 
 
-@patch("vega_sim.api.data.asset_decimals")
+@patch("vega_sim.api.get_asset_decimals")
 @patch("vega_sim.api.data.market_price_decimals")
 @patch("vega_sim.api.data.market_position_decimals")
 @patch("vega_sim.api.data_raw.market_info")
@@ -925,7 +925,7 @@ def test_get_trades(
     assert res == expected
 
 
-@patch("vega_sim.api.data.asset_decimals")
+@patch("vega_sim.api.get_asset_decimals")
 def test_list_transfers(
     mk_asset_decimals,
     trading_data_v2_servicer_and_port,

--- a/tests/vega_sim/api/test_data.py
+++ b/tests/vega_sim/api/test_data.py
@@ -646,7 +646,7 @@ def test_order_subscription(mkt_price_mock, mkt_pos_mock, core_servicer_and_port
         assert order.id == next(queue).id
 
 
-@patch("vega_sim.api.get_asset_decimals")
+@patch("vega_sim.api.data.get_asset_decimals")
 def test_transfer_subscription(mk_asset_decimals, core_servicer_and_port):
     mk_asset_decimals.return_value = 1
     transfers = [
@@ -771,7 +771,7 @@ def test_transfer_subscription(mk_asset_decimals, core_servicer_and_port):
         assert transfer.id == next(queue).id
 
 
-@patch("vega_sim.api.get_asset_decimals")
+@patch("vega_sim.api.data.get_asset_decimals")
 def test_market_limits(mk_asset_decimals, trading_data_v2_servicer_and_port):
     expected = [
         MarginLevels(
@@ -829,7 +829,7 @@ def test_market_limits(mk_asset_decimals, trading_data_v2_servicer_and_port):
     assert res == expected
 
 
-@patch("vega_sim.api.get_asset_decimals")
+@patch("vega_sim.api.data.get_asset_decimals")
 @patch("vega_sim.api.data.market_price_decimals")
 @patch("vega_sim.api.data.market_position_decimals")
 @patch("vega_sim.api.data_raw.market_info")
@@ -925,7 +925,7 @@ def test_get_trades(
     assert res == expected
 
 
-@patch("vega_sim.api.get_asset_decimals")
+@patch("vega_sim.api.data.get_asset_decimals")
 def test_list_transfers(
     mk_asset_decimals,
     trading_data_v2_servicer_and_port,

--- a/vega_sim/api/data.py
+++ b/vega_sim/api/data.py
@@ -297,7 +297,7 @@ def list_accounts(
     output_accounts = []
     for account in accounts:
         if account.asset not in asset_decimals_map:
-            asset_decimals_map[account.asset] = asset_decimals(
+            asset_decimals_map[account.asset] = get_asset_decimals(
                 asset_id=account.asset,
                 data_client=data_client,
             )
@@ -332,7 +332,7 @@ def party_account(
     )
 
     asset_dp = (
-        asset_dp if asset_dp is not None else asset_decimals(asset_id, data_client)
+        asset_dp if asset_dp is not None else get_asset_decimals(asset_id, data_client)
     )
 
     general, margin, bond = 0, 0, 0  # np.nan, np.nan, np.nan
@@ -468,7 +468,7 @@ def market_position_decimals(
     ).position_decimal_places
 
 
-def asset_decimals(
+def get_asset_decimals(
     asset_id: str,
     data_client: vac.VegaTradingDataClientV2,
 ) -> int:
@@ -749,7 +749,7 @@ def market_account(
     )
     acct = {account.type: account for account in accounts}[account_type]
 
-    asset_dp = asset_decimals(asset_id=acct.asset, data_client=data_client)
+    asset_dp = get_asset_decimals(asset_id=acct.asset, data_client=data_client)
     return num_from_padded_int(
         acct.balance,
         asset_dp,
@@ -877,7 +877,7 @@ def transfer_subscription(
                 for bus_event in transfer_list.events:
                     transfer = bus_event.transfer
                     if transfer.asset not in asset_dp:
-                        asset_dp[transfer.asset] = asset_decimals(
+                        asset_dp[transfer.asset] = get_asset_decimals(
                             asset_id=transfer.asset,
                             data_client=trading_data_client,
                         )
@@ -924,7 +924,7 @@ def margin_levels(
     res_margins = []
     for margin in margins:
         if margin.asset not in asset_dp:
-            asset_dp[margin.asset] = asset_decimals(
+            asset_dp[margin.asset] = get_asset_decimals(
                 asset_id=margin.asset, data_client=data_client
             )
         res_margins.append(
@@ -963,7 +963,7 @@ def get_trades(
                 market_id=trade.market_id, data_client=data_client
             )
         if trade.market_id not in market_asset_decimals_map:
-            market_asset_decimals_map[trade.market_id] = asset_decimals(
+            market_asset_decimals_map[trade.market_id] = get_asset_decimals(
                 asset_id=data_raw.market_info(
                     market_id=market_id, data_client=data_client
                 ).tradable_instrument.instrument.future.settlement_asset,
@@ -1016,7 +1016,7 @@ def list_transfers(
     for transfer in transfers:
 
         if transfer.asset not in asset_dp:
-            asset_dp[transfer.asset] = asset_decimals(
+            asset_dp[transfer.asset] = get_asset_decimals(
                 asset_id=transfer.asset, data_client=data_client
             )
 

--- a/vega_sim/api/data_raw.py
+++ b/vega_sim/api/data_raw.py
@@ -35,15 +35,19 @@ def unroll_v2_pagination(
 
 def positions_by_market(
     pub_key: str,
-    market_id: str,
     data_client: vac.VegaTradingDataClientV2,
+    market_id: Optional[str] = None,
 ) -> List[vega_protos.vega.Position]:
     """Output positions of a party."""
+
+    base_request = data_node_protos_v2.trading_data.ListPositionsRequest(
+        party_id=pub_key,
+    )
+    if market_id is not None:
+        setattr(base_request, "market_id", market_id)
+
     return unroll_v2_pagination(
-        base_request=data_node_protos_v2.trading_data.ListPositionsRequest(
-            party_id=pub_key,
-            market_id=market_id,
-        ),
+        base_request=base_request,
         request_func=lambda x: data_client.ListPositions(x).positions,
         extraction_func=lambda res: [i.node for i in res.edges],
     )

--- a/vega_sim/parameter_test/parameter/loggers.py
+++ b/vega_sim/parameter_test/parameter/loggers.py
@@ -102,16 +102,16 @@ def _ideal_market_maker_single_data_extraction(
         market_id=mm_agent.market_id,
         key_name=mm_agent.key_name,
     )
-    if not position:
+    if position is None:
         realised_pnl_lp = 0
         unrealised_pnl_lp = 0
         inventory_lp = 0
         entry_price = 0
     else:
-        realised_pnl_lp = round(float(position[0].realised_pnl), mm_agent.adp)
-        unrealised_pnl_lp = round(float(position[0].unrealised_pnl), mm_agent.adp)
-        inventory_lp = float(position[0].open_volume)
-        entry_price = float(position[0].average_entry_price) / 10**mm_agent.mdp
+        realised_pnl_lp = round(float(position.realised_pnl), mm_agent.adp)
+        unrealised_pnl_lp = round(float(position.unrealised_pnl), mm_agent.adp)
+        inventory_lp = float(position.open_volume)
+        entry_price = float(position.average_entry_price) / 10**mm_agent.mdp
 
     market_state = vega.market_info(market_id=mm_agent.market_id).state
     market_data = vega.market_data(market_id=mm_agent.market_id)
@@ -329,16 +329,16 @@ def momentum_trader_data_extraction(
         wallet_name=trader.wallet_name, market_id=trader.market_id
     )
 
-    if not position:
+    if position is None:
         realised_pnl = 0
         unrealised_pnl = 0
         inventory = 0
         entry_price = 0
     else:
-        realised_pnl = round(float(position[0].realised_pnl), trader.adp)
-        unrealised_pnl = round(float(position[0].unrealised_pnl), trader.adp)
-        inventory = float(position[0].open_volume)
-        entry_price = float(position[0].average_entry_price) / 10**trader.mdp
+        realised_pnl = round(float(position.realised_pnl), trader.adp)
+        unrealised_pnl = round(float(position.unrealised_pnl), trader.adp)
+        inventory = float(position.open_volume)
+        entry_price = float(position.average_entry_price) / 10**trader.mdp
 
     market_data = vega.market_data(market_id=trader.market_id)
     markprice = float(market_data.mark_price) / 10**trader.mdp
@@ -382,16 +382,16 @@ def uninformed_tradingbot_data_extraction(
         wallet_name=trader.wallet_name, market_id=trader.market_id
     )
 
-    if not position:
+    if position is None:
         realised_pnl = 0
         unrealised_pnl = 0
         inventory = 0
         entry_price = 0
     else:
-        realised_pnl = round(float(position[0].realised_pnl), trader.adp)
-        unrealised_pnl = round(float(position[0].unrealised_pnl), trader.adp)
-        inventory = float(position[0].open_volume)
-        entry_price = float(position[0].average_entry_price) / 10**trader.mdp
+        realised_pnl = round(float(position.realised_pnl), trader.adp)
+        unrealised_pnl = round(float(position.unrealised_pnl), trader.adp)
+        inventory = float(position.open_volume)
+        entry_price = float(position.average_entry_price) / 10**trader.mdp
 
     logs = {
         "UT: General Account": general,

--- a/vega_sim/reinforcement/agents/learning_agent.py
+++ b/vega_sim/reinforcement/agents/learning_agent.py
@@ -164,7 +164,7 @@ class LearningAgent(StateAgentWithWallet):
     def state(self, vega: VegaServiceNull) -> LAMarketState:
         position = self.vega.positions_by_market(self.wallet_name, self.market_id)
 
-        position = position[0].open_volume if position else 0
+        position = position.open_volume if position else 0
         account = self.vega.party_account(
             wallet_name=self.wallet_name,
             asset_id=self.tdai_id,

--- a/vega_sim/reinforcement/agents/simple_agent.py
+++ b/vega_sim/reinforcement/agents/simple_agent.py
@@ -69,8 +69,7 @@ self.vega.cancel_order(
 positions = self.vega.positions_by_market(
     wallet_name=self.wallet_name, market_id=self.market_id
 )
-if len(positions) > 0:
-    position = positions[0]
+if position is not None:
     volume = position.open_volume
     pnl = position.realised_pnl + position.unrealised_pnl
     entry_price = position.average_entry_price

--- a/vega_sim/scenario/common/agents.py
+++ b/vega_sim/scenario/common/agents.py
@@ -1079,7 +1079,7 @@ class ShapedMarketMaker(StateAgentWithWallet):
             key_name=self.key_name,
         )
 
-        current_position = int(position[0].open_volume) if position else 0
+        current_position = int(position.open_volume) if position is not None else 0
         self.bid_depth, self.ask_depth = self.best_price_offset_fn(
             current_position, self.current_step
         )
@@ -1666,21 +1666,19 @@ class HedgedMarketMaker(ExponentialShapedMarketMaker):
     def _balance_positions(self):
         # Determine the delta between the position on the internal and external market
 
-        internal_position = self.vega.positions_by_market(
+        positions = self.vega.positions_by_market(
             wallet_name=self.wallet_name,
-            market_id=self.market_id,
             key_name=self.key_name,
         )
         current_int_position = (
-            internal_position[0].open_volume if internal_position != [] else 0
-        )
-        external_position = self.vega.positions_by_market(
-            wallet_name=self.wallet_name,
-            market_id=self.external_market_id,
-            key_name=self.external_key_name,
+            float(positions[self.market_id].open_volume)
+            if positions is not None and self.market_id in positions
+            else 0
         )
         current_ext_position = (
-            float(external_position[0].open_volume) if external_position != [] else 0
+            float(positions[self.external_market_id].open_volume)
+            if positions is not None and self.external_market_id in positions
+            else 0
         )
         position_delta = current_int_position + current_ext_position
 
@@ -2179,7 +2177,7 @@ class InformedTrader(StateAgentWithWallet):
             market_id=self.market_id,
             key_name=self.key_name,
         )
-        abs_position = abs(int(position[0].open_volume) if position else 0)
+        abs_position = abs(int(position.open_volume) if position is not None else 0)
         if abs_position + size > self.max_abs_position:
             size = min([0, self.max_abs_position - abs_position])
 

--- a/vega_sim/scenario/ideal_market_maker/agents.py
+++ b/vega_sim/scenario/ideal_market_maker/agents.py
@@ -293,7 +293,7 @@ class OptimalMarketMaker(StateAgentWithWallet):
             key_name=self.key_name,
         )
 
-        current_position = int(position[0].open_volume) if position else 0
+        current_position = int(position.open_volume) if position is not None else 0
         self.bid_depth, self.ask_depth = self.OptimalStrategy(current_position)
 
         self.num_buyMO, self.num_sellMO = self.num_MarketOrders()
@@ -784,7 +784,7 @@ class OptimalLiquidityProvider(StateAgentWithWallet):
             key_name=self.key_name,
         )
 
-        current_position = int(position[0].open_volume) if position else 0
+        current_position = int(position.open_volume) if position is not None else 0
         self.bid_depth, self.ask_depth = self.OptimalStrategy(current_position)
 
         self.vega.submit_simple_liquidity(
@@ -855,7 +855,7 @@ class InformedTrader(StateAgentWithWallet):
             market_id=self.market_id,
             key_name=self.key_name,
         )
-        current_position = int(position[0].open_volume) if position else 0
+        current_position = int(position.open_volume) if position is not None else 0
         trade_side = (
             vega_protos.vega.Side.SIDE_BUY
             if current_position < 0

--- a/vega_sim/scenario/ideal_market_maker_v2/agents.py
+++ b/vega_sim/scenario/ideal_market_maker_v2/agents.py
@@ -250,7 +250,7 @@ class OptimalMarketMaker(StateAgentWithWallet):
             key_name=self.key_name,
         )
 
-        current_position = int(position[0].open_volume) if position else 0
+        current_position = int(position.open_volume) if position is not None else 0
         self.bid_depth, self.ask_depth = self.optimal_strategy(current_position)
 
         buy_order, sell_order = None, None

--- a/vega_sim/service.py
+++ b/vega_sim/service.py
@@ -1015,16 +1015,25 @@ class VegaService(ABC):
         )
 
     def positions_by_market(
-        self, wallet_name: str, market_id: str, key_name: Optional[str] = None
+        self,
+        wallet_name: str,
+        market_id: Optional[str] = None,
+        key_name: Optional[str] = None,
     ) -> List[vega_protos.vega.Position]:
         """Output positions of a party."""
         return data.positions_by_market(
-            self.wallet.public_key(wallet_name, key_name),
+            pub_key=self.wallet.public_key(wallet_name, key_name),
             market_id=market_id,
             data_client=self.trading_data_client_v2,
-            asset_decimals=self.asset_decimals[self.market_to_asset[market_id]],
-            price_decimals=self.market_price_decimals[market_id],
-            position_decimals=self.market_pos_decimals[market_id],
+            asset_decimals=self.asset_decimals[self.market_to_asset[market_id]]
+            if market_id is not None
+            else None,
+            price_decimals=self.market_price_decimals[market_id]
+            if market_id is not None
+            else None,
+            position_decimals=self.market_pos_decimals[market_id]
+            if market_id is not None
+            else None,
         )
 
     @raw_data

--- a/vega_sim/service.py
+++ b/vega_sim/service.py
@@ -166,7 +166,7 @@ class VegaService(ABC):
     def asset_decimals(self) -> int:
         if self._asset_decimals is None:
             self._asset_decimals = DecimalsCache(
-                lambda asset_id: data.asset_decimals(
+                lambda asset_id: data.get_asset_decimals(
                     asset_id=asset_id, data_client=self.trading_data_client_v2
                 )
             )

--- a/vega_sim/service.py
+++ b/vega_sim/service.py
@@ -1025,15 +1025,10 @@ class VegaService(ABC):
             pub_key=self.wallet.public_key(wallet_name, key_name),
             market_id=market_id,
             data_client=self.trading_data_client_v2,
-            asset_decimals=self.asset_decimals[self.market_to_asset[market_id]]
-            if market_id is not None
-            else None,
-            price_decimals=self.market_price_decimals[market_id]
-            if market_id is not None
-            else None,
-            position_decimals=self.market_pos_decimals[market_id]
-            if market_id is not None
-            else None,
+            market_price_decimals_map=self.market_price_decimals,
+            market_position_decimals_map=self.market_pos_decimals,
+            market_to_asset_map=self.market_to_asset,
+            asset_decimals_map=self.asset_decimals,
         )
 
     @raw_data


### PR DESCRIPTION
### Description
The `positions_by_market` method has been generalised to allow no `market_id` to be specified. In this scenario the method returns the positions of the party in each market in which it has an open position.

### Testing
Passing all tests locally.

### Breaking Changes
1. `positions_by_market` no longer returns a list of positions for the specified party and market. The method has been generalised to allow a `market_id` to be an optional arg.
    - If a `market_id` is specified:  returns a single `Position` object for the specified party and market.
    - If no `market_id` is specified:  returns all positions for the party as a dict (`market_id` keys, `Position` values).
1. If no positions are found for a party, or for a party within a specified market, an empty list is no longer returned. Instead, a `None` value is returned.

All uses of `positions_by_market` have been updated to reflect the changes.

### Closes
Closes #285 
