### PR TITLE
feat: Removing tag from asset

### DIFF
--- a/tests/integration/test_reinforcement.py
+++ b/tests/integration/test_reinforcement.py
@@ -6,4 +6,4 @@ def test_rl_run():
     # Simply testing that it doesn't error
     import vega_sim.reinforcement.run_rl_agent as rl
 
-    rl._run(1)
+    rl._run(3)

--- a/vega_sim/reinforcement/agents/learning_agent.py
+++ b/vega_sim/reinforcement/agents/learning_agent.py
@@ -66,6 +66,7 @@ class LearningAgent(StateAgentWithWallet):
         market_name: str,
         initial_balance: int,
         position_decimals: int,
+        asset_name: str,
         inventory_penalty: float = 0.0,
     ):
         super().__init__(wallet_name=wallet_name, wallet_pass=wallet_pass)
@@ -94,6 +95,7 @@ class LearningAgent(StateAgentWithWallet):
         self.market_name = market_name
         self.position_decimals = position_decimals
         self.inventory_penalty = inventory_penalty
+        self.asset_name = asset_name
 
     def set_market_tag(self, tag: str):
         self.tag = tag
@@ -119,7 +121,7 @@ class LearningAgent(StateAgentWithWallet):
             if m.tradable_instrument.instrument.name == market_name
         ][0]
         # Get asset id
-        self.tdai_id = self.vega.find_asset_id(symbol=f"tDAI_{self.tag}")
+        self.tdai_id = self.vega.find_asset_id(symbol=self.asset_name)
         # Top up asset
         self.vega.mint(
             self.wallet_name,

--- a/vega_sim/reinforcement/agents/learning_agent_MO.py
+++ b/vega_sim/reinforcement/agents/learning_agent_MO.py
@@ -61,6 +61,7 @@ class LearningAgentFixedVol(LearningAgent):
         market_name: str,
         initial_balance: int,
         position_decimals: int,
+        asset_name: str,
         inventory_penalty: float = 1.0,
     ):
         super().__init__(
@@ -76,6 +77,7 @@ class LearningAgentFixedVol(LearningAgent):
             initial_balance=initial_balance,
             position_decimals=position_decimals,
             inventory_penalty=inventory_penalty,
+            asset_name=asset_name,
         )
         self.volume = 10 ** (-self.position_decimals)
 

--- a/vega_sim/reinforcement/run_rl_agent.py
+++ b/vega_sim/reinforcement/run_rl_agent.py
@@ -27,6 +27,7 @@ def run_iteration(
     step_tag: int,
     vega: VegaServiceNull,
     market_name: str,
+    asset_name: str,
     run_with_console=False,
     pause_at_completion=False,
 ):
@@ -46,6 +47,7 @@ def run_iteration(
         num_steps=50,
         random_agent_ordering=False,
         sigma=100,
+        asset_name=asset_name,
     )
 
     scenario.agents = scenario.configure_agents(
@@ -91,6 +93,7 @@ def _run(
 
     # set market name
     market_name = "ETH:USD"
+    asset_name = "tDAI"
     position_decimals = 2
 
     if not os.path.exists(results_dir):
@@ -114,6 +117,7 @@ def _run(
         market_name=market_name,
         position_decimals=position_decimals,
         inventory_penalty=0.1,
+        asset_name=asset_name,
     )
 
     with VegaServiceNull(
@@ -147,6 +151,7 @@ def _run(
                     step_tag=it,
                     vega=vega,
                     market_name=market_name,
+                    asset_name=asset_name,
                     run_with_console=False,
                     pause_at_completion=False,
                 )

--- a/vega_sim/scenario/curve_market_maker/scenario.py
+++ b/vega_sim/scenario/curve_market_maker/scenario.py
@@ -129,7 +129,7 @@ class CurveMarketMaker(Scenario):
     ) -> List[StateAgent]:
         # Set up market name and settlement asset
         market_name = self.market_name + (f"_{tag}" if tag else "")
-        asset_name = self.asset_name + (f"_{tag}" if tag else "")
+        asset_name = self.asset_name
 
         price_process = (
             self.price_process_fn()


### PR DESCRIPTION
### Description
<!---
What is the change?
--->
Removing tag from asset in RL runs, meaning that new parties will use the same asset, just on a new market.
This should improve the performance of the RL runs as creating large numbers of assets appears to slow down the simulation run across the day.

### Testing
<!---
How has the change been tested? Were new unit/integration tests added and do current ones cover?
--->
Tests pass and a few runs of RL look fine. Will run on the nightly Jenkins RL job to see whether it ultimately improves things

### Breaking Changes
<!---
Are any of the changes in this PR breaking/requiring of a change in workflow?
--->
None

### Closes
<!---
Does this close any issues?
--->
