### PR TITLE
feat: add ParameterExperiment scenario

### DIFF
--- a/vega_sim/parameter_test/parameter/configs.py
+++ b/vega_sim/parameter_test/parameter/configs.py
@@ -8,6 +8,7 @@ from vega_sim.parameter_test.parameter.loggers import (
 )
 from vega_sim.scenario.configurable_market.scenario import ConfigurableMarket
 from vega_sim.scenario.curve_market_maker.scenario import CurveMarketMaker
+from vega_sim.scenario.parameter_experiment.scenario import ParameterExperiment
 from vega_sim.scenario.registry import IdealMarketMaker, IdealMarketMakerV2
 from vega_sim.parameter_test.parameter.loggers import (
     BASE_IDEAL_MM_CSV_HEADERS,
@@ -22,28 +23,13 @@ from vega_sim.scenario.common.utils.price_process import (
     get_historic_price_series,
 )
 
-TARGET_STAKE_SCALING_FACTOR_IDEAL = SingleParameterExperiment(
-    name="StakeTargetScaling",
+TARGET_STAKE_SCALING_FACTOR = SingleParameterExperiment(
+    name="TargetStakeScalingFactor",
     parameter_to_vary="market.stake.target.scalingFactor",
     values=["0.5", "5", "50"],
-    scenario=IdealMarketMaker(
-        num_steps=288,
-        market_decimal=3,
-        asset_decimal=5,
-        market_position_decimal=2,
-        spread=0.002,
-        initial_asset_mint=1e8,
-        lp_initial_mint=1e8,
-        lp_commitamount=50000,
-        initial_price=1123.11,
-        sigma=0.1,
-        kappa=50,
-        lambda_val=10,
-        q_upper=50,
-        q_lower=-50,
+    scenario=ParameterExperiment(
         state_extraction_fn=ideal_market_maker_single_data_extraction(
             additional_data_fns=[
-                v1_ideal_mm_additional_data,
                 tau_scaling_additional_data,
                 target_stake_additional_data,
                 limit_order_book,
@@ -290,7 +276,7 @@ MARKET_PARAMETER_DEMO = SingleParameterExperiment(
 
 
 CONFIGS = [
-    TARGET_STAKE_SCALING_FACTOR_IDEAL,
+    TARGET_STAKE_SCALING_FACTOR,
     TAU_SCALING_FACTOR_IDEAL,
     TAU_SCALING_FACTOR_IDEAL_v2,
     TARGET_STAKE_SCALING_FACTOR_IDEAL_v2,

--- a/vega_sim/scenario/common/agents.py
+++ b/vega_sim/scenario/common/agents.py
@@ -304,6 +304,86 @@ class PriceSensitiveMarketOrderTrader(StateAgentWithWallet):
             )
 
 
+class PriceSensitiveLimitOrderTrader(StateAgentWithWallet):
+    NAME_BASE = "price_sensitive_lo_trader"
+
+    def __init__(
+        self,
+        wallet_name: str,
+        wallet_pass: str,
+        market_name: str,
+        asset_name: str,
+        price_process_generator: Iterable[float],
+        initial_asset_mint: float = 1000000,
+        scale: float = 0.5,
+        max_order_size: float = 100,
+        random_state: Optional[np.random.RandomState] = None,
+        key_name: str = None,
+        tag: str = "",
+    ):
+        super().__init__(
+            wallet_name=wallet_name, wallet_pass=wallet_pass, key_name=key_name, tag=tag
+        )
+        self.market_name = market_name
+        self.asset_name = asset_name
+        self.price_process_generator = price_process_generator
+        self.initial_asset_mint = initial_asset_mint
+        self.scale = scale
+        self.max_order_size = max_order_size
+        self.random_state = (
+            random_state if random_state is not None else np.random.RandomState()
+        )
+
+    def initialise(
+        self,
+        vega: Union[VegaServiceNull, VegaServiceNetwork],
+        create_wallet: bool = True,
+        mint_wallet: bool = True,
+    ):
+        # Initialise wallet
+        super().initialise(vega=vega, create_wallet=create_wallet)
+        # Get market id
+        self.market_id = self.vega.find_market_id(name=self.market_name)
+
+        # Get asset id
+        self.asset_id = self.vega.find_asset_id(symbol=self.asset_name)
+        if mint_wallet:
+            # Top up asset
+            self.vega.mint(
+                self.wallet_name,
+                asset=self.asset_id,
+                amount=self.initial_asset_mint,
+                key_name=self.key_name,
+            )
+        self.vega.wait_fn(5)
+
+    def step(self, vega_state: VegaState):
+        self.curr_price = next(self.price_process_generator)
+
+        bid_price = self.curr_price + self.random_state.exponential(scale=self.scale)
+        self.place_order(side="SIDE_BUY", price=bid_price)
+
+        ask_price = self.curr_price - self.random_state.exponential(scale=self.scale)
+        self.place_order(side="SIDE_SELL", price=ask_price)
+
+    def place_order(
+        self,
+        side,
+        price,
+    ):
+        self.vega.submit_order(
+            trading_wallet=self.wallet_name,
+            key_name=self.key_name,
+            market_id=self.market_id,
+            order_type="TYPE_LIMIT",
+            time_in_force="TIME_IN_FORCE_IOC",
+            side=side,
+            volume=self.max_order_size,
+            price=price,
+            wait=False,
+        )
+
+
 class BackgroundMarket(StateAgentWithWallet):
     NAME_BASE = "background_market"
 

--- a/vega_sim/scenario/common/agents.py
+++ b/vega_sim/scenario/common/agents.py
@@ -2184,9 +2184,12 @@ class InformedTrader(StateAgentWithWallet):
             market_id=self.market_id,
             key_name=self.key_name,
         )
-        abs_position = abs(int(position.open_volume) if position is not None else 0)
-        if abs_position + size > self.max_abs_position:
-            size = min([0, self.max_abs_position - abs_position])
+        cur_position = int(position.open_volume) if position is not None else 0
+        new_position = (
+            cur_position + size if side == vega_protos.SIDE_BUY else cur_position - size
+        )
+        if abs(new_position) > self.max_abs_position:
+            size = max([0, self.max_abs_position - abs(cur_position)])
 
         # Add a random probability the agent speculates the wrong side
         if self.random_state.rand() <= self.accuracy:

--- a/vega_sim/scenario/parameter_experiment/scenario.py
+++ b/vega_sim/scenario/parameter_experiment/scenario.py
@@ -1,0 +1,276 @@
+"""scenario.py
+
+Module contains the ParameterExperiment scenario class, which simulates a scenario for
+use in network parameter and market parameter experiments. The scenario uses the
+following suite of vega-market-sim agents.
+
+- ConfigurableMarketManager:        proposes and settles a fully configurable market.
+- ExponentialShapedMarketMaker:     provides liquidity and an order book in the market.
+- RandomMarketOrderTrader:          trades each side of the book every step.
+- PriceSensitiveLimitOrderTrader:   trades on orders close to an external price.
+- InformedTrader:                   trades on orders which will be in-the-money soon.
+
+"""
+
+import numpy as np
+
+from datetime import datetime, timedelta
+from typing import Any, Dict, Callable, Optional
+
+from vega_sim.api.market import MarketConfig
+from vega_sim.scenario.scenario import Scenario
+from vega_sim.environment.environment import MarketEnvironmentWithState
+from vega_sim.null_service import VegaServiceNull
+
+from vega_sim.environment.agent import Agent
+from vega_sim.scenario.configurable_market.scenario import ConfigurableMarketManager
+from vega_sim.scenario.common.agents import (
+    OpenAuctionPass,
+    MarketOrderTrader,
+    ExponentialShapedMarketMaker,
+    PriceSensitiveLimitOrderTrader,
+    InformedTrader,
+    StateAgent,
+)
+
+from vega_sim.scenario.common.utils.price_process import (
+    Granularity,
+    get_historic_price_series,
+)
+
+
+
+class ParameterExperiment(Scenario):
+    """Class simulates a scenario for use in parameter experiments.
+
+    The default values for the ParameterExperiment scenario are to simulate a daily
+    ETH:USD future with trading activity in five minute steps.
+
+    """
+
+    def __init__(
+        self,
+        num_steps: int = 360,
+        granularity: Optional[Granularity] = Granularity.MINUTE,
+        block_size: int = 100,
+        block_length_seconds: int = 1,
+        state_extraction_fn: Optional[
+            Callable[[VegaServiceNull, Dict[str, Agent]], Any]
+        ] = None,
+        settle_at_end: bool = True,
+        price_process_fn: Optional[Callable] = None,
+        market_name: Optional[str] = "ETH:USD (6hr Future)",
+        market_code: str = "ETHUSD",
+        asset_name: str = "ETH",
+        asset_dp: str = 18,
+        rt_mint: int = 10_000,
+        it_mint: int = 10_000,
+        st_mint: int = 1_000_000,
+    ):
+        super().__init__(state_extraction_fn=state_extraction_fn)
+
+        # Simulation settings
+        self.num_steps = num_steps
+        self.granularity = granularity
+        self.block_size = block_size
+        self.block_length_seconds = block_length_seconds
+        self.settle_at_end = settle_at_end
+        self.price_process_fn = price_process_fn
+
+        # Asset info parameters
+        self.asset_name = asset_name
+        self.asset_decimal = asset_dp
+
+        # Market info parameters
+        self.market_name = market_name
+        self.market_code = market_code
+
+        # Agent mint parameters
+        self.rt_mint = rt_mint
+        self.st_mint = st_mint
+        self.it_mint = it_mint
+
+
+    def _generate_price_process(
+        self,
+        random_state,
+    ) -> list:
+
+        # Select a random start and end datetime
+        start = datetime.strptime(
+            "2022-01-01 00:00:00", "%Y-%m-%d %H:%M:%S"
+        ) + timedelta(days=int(random_state.choice(range(90))))
+        end = start + timedelta(seconds=(self.num_steps + 1) * self.granularity.value)
+
+        # Get the historic price process between the randomly generated dates
+        price_process = get_historic_price_series(
+            product_id="ETH-USD",
+            granularity=self.granularity,
+            start=str(start),
+            end=str(end),
+        )
+
+        return list(price_process)
+
+    def configure_agents(
+        self,
+        vega: VegaServiceNull,
+        tag: str,
+        market_config: Optional[MarketConfig] = None,
+        random_state: Optional[np.random.RandomState] = None,
+    ) -> Dict[str, StateAgent]:
+        market_config = market_config if market_config is not None else MarketConfig()
+
+        random_state = (
+            random_state if random_state is not None else np.random.RandomState()
+        )
+
+        market_name = self.market_name
+        asset_name = self.asset_name
+
+        price_process = (
+            self.price_process_fn()
+            if self.price_process_fn is not None
+            else self._generate_price_process(random_state=random_state)
+        )
+
+        market_manager = ConfigurableMarketManager(
+            proposal_wallet_name="vega",
+            proposal_wallet_pass="pass",
+            proposal_key_name="market_proposer",
+            termination_wallet_name="vega",
+            termination_wallet_pass="pass",
+            termination_key_name="market_settler",
+            market_config=market_config,
+            market_name=market_name,
+            market_code=self.market_code,
+            asset_dp=self.asset_decimal,
+            asset_name=asset_name,
+            settlement_price=price_process[-1] if self.settle_at_end else None,
+            tag=None,
+        )
+
+        market_maker = ExponentialShapedMarketMaker(
+            wallet_name="vega",
+            wallet_pass="pass",
+            key_name="market_maker",
+            price_process_generator=iter(price_process),
+            initial_asset_mint=1e9,
+            commitment_amount=500_000,
+            fee_amount=0.0003,
+            market_name=market_name,
+            asset_name=asset_name,
+            market_decimal_places=market_config.decimal_places,
+            asset_decimal_places=self.asset_decimal,
+            num_steps=self.num_steps,
+            kappa=5,
+            num_levels=20,
+            tick_spacing=0.01,
+            inventory_upper_boundary=20,
+            inventory_lower_boundary=-20,
+            market_kappa=5,
+            market_order_arrival_rate=0.5,
+            state_update_freq=10,
+            tag=None,
+        )
+
+        # Create fixed auction pass agents
+        open_auction_pass_bid = OpenAuctionPass(
+            wallet_name="vega",
+            wallet_pass="pass",
+            key_name="auction_trader_bid",
+            side="SIDE_BUY",
+            initial_asset_mint=1e9,
+            initial_price=price_process[0],
+            market_name=market_name,
+            asset_name=asset_name,
+            opening_auction_trade_amount=market_config.position_decimal_places,
+            tag="bid",
+        )
+        open_auction_pass_ask = OpenAuctionPass(
+            wallet_name="vega",
+            wallet_pass="pass",
+            key_name="auction_trader_ask",
+            side="SIDE_SELL",
+            initial_asset_mint=1e9,
+            initial_price=price_process[0],
+            market_name=market_name,
+            asset_name=asset_name,
+            opening_auction_trade_amount=market_config.position_decimal_places,
+            tag="ask",
+        )
+
+        informed_trader = InformedTrader(
+            wallet_name="vega",
+            wallet_pass="pass",
+            key_name="informed_trade",
+            price_process=price_process,
+            market_name=market_name,
+            asset_name=asset_name,
+            initial_asset_mint=self.it_mint,
+            proportion_taken=0.05,
+            lookahead=5,
+            accuracy=0.8,
+            max_abs_position=20,
+            tag=None,
+        )
+
+        random_traders = [
+            MarketOrderTrader(
+                wallet_name="vega",
+                wallet_pass="pass",
+                key_name=f"random_trader_{i}",
+                market_name=market_name,
+                asset_name=asset_name,
+                initial_asset_mint=self.rt_mint,
+                base_order_size=0.1,
+                buy_intensity=buy_intensity,
+                sell_intensity=sell_intensity,
+                tag=str(i),
+            )
+            for i, (buy_intensity, sell_intensity) in enumerate(
+                [(50, 10), (30, 30), (30, 30), (30, 30), (10, 50)]
+            )
+        ]
+
+        # Create fixed sensitive_traders
+        sensitive_traders = [
+            PriceSensitiveLimitOrderTrader(
+                wallet_name="vega",
+                wallet_pass="pass",
+                key_name="sensitive_trader",
+                market_name=market_name,
+                asset_name=asset_name,
+                initial_asset_mint=self.st_mint,
+                max_order_size=50,
+                scale=0.035,
+                price_process_generator=iter(price_process),
+            )
+            for _ in range(5)
+        ]
+
+        agents = (
+            [
+                market_manager,
+                market_maker,
+                open_auction_pass_bid,
+                open_auction_pass_ask,
+                informed_trader,
+            ]
+            + sensitive_traders
+            + random_traders
+        )
+        return {agent.name(): agent for agent in agents}
+
+    def configure_environment(
+        self, vega: VegaServiceNull, **kwargs
+    ) -> MarketEnvironmentWithState:
+        return MarketEnvironmentWithState(
+            agents=list(self.agents.values()),
+            n_steps=self.num_steps,
+            step_length_seconds=self.granularity.value,
+            random_agent_ordering=True,
+            transactions_per_block=self.block_size,
+            vega_service=vega,
+            block_length_seconds=self.block_length_seconds,
+        )

--- a/vega_sim/scenario/parameter_experiment/scenario.py
+++ b/vega_sim/scenario/parameter_experiment/scenario.py
@@ -39,7 +39,6 @@ from vega_sim.scenario.common.utils.price_process import (
 )
 
 
-
 class ParameterExperiment(Scenario):
     """Class simulates a scenario for use in parameter experiments.
 
@@ -89,7 +88,6 @@ class ParameterExperiment(Scenario):
         self.rt_mint = rt_mint
         self.st_mint = st_mint
         self.it_mint = it_mint
-
 
     def _generate_price_process(
         self,

--- a/vega_sim/scenario/registry.py
+++ b/vega_sim/scenario/registry.py
@@ -10,6 +10,8 @@ from vega_sim.scenario.multi_market.scenario import VegaLoadTest
 from vega_sim.scenario.market_crash.scenario import MarketCrash
 from vega_sim.scenario.configurable_market.scenario import ConfigurableMarket
 from vega_sim.scenario.hedged_market_maker.scenario import HedgedMarket
+from vega_sim.scenario.parameter_experiment.scenario import ParameterExperiment
+
 
 from vega_sim.scenario.common.utils.price_process import (
     get_historic_price_series,
@@ -193,4 +195,5 @@ SCENARIOS = {
         int_lock=3 * 60 * 60,
         ext_lock=5 * 60,
     ),
+    "parameter_experiment": lambda: ParameterExperiment(),
 }

--- a/vega_sim/vegahome/genesis.json
+++ b/vega_sim/vegahome/genesis.json
@@ -103,7 +103,7 @@
       "market.auction.maximumDuration": "168h0m0s",
       "market.auction.minimumDuration": "1s",
       "market.fee.factors.infrastructureFee": "0.001",
-      "market.fee.factors.makerFee": "0.001",
+      "market.fee.factors.makerFee": "0.0002",
       "market.liquidity.bondPenaltyParameter": "1",
       "market.liquidity.maximumLiquidityFeeFactorLevel": "1",
       "market.liquidity.minimum.probabilityOfTrading.lpOrders": "1e-8",


### PR DESCRIPTION
### Description
PR adds a `ParameterExperiment` scenario for use in both network and market parameter experiments. Scenario has the following key features.

- Configured for 6hrs of trading in 1min steps on an ETHUSD market (gives a 30s sim runtime).
- Can proposes and settles fully configurable markets with the `ConfigurableMarketManager` agent.
- Uses the latest `ExponentialShapedMarketMaker` agent tuned for an ETHUSD market.
- `RandomMarketOrderTraders` agents with un-balanced buy/sell intensities create parties at risk of close-outs.
- Toxic `InformedTrader` agents look ahead and fill orders which will be in the money at a certain point in the future.
- `PriceSensitiveLimitOrderTraders` exploit orders made by the MM when it is overexposed or slow to react to price movements (i.e. when the mm steps after the traders).

![OpenInterest and Position](https://user-images.githubusercontent.com/99198652/212372677-78582220-a949-4e32-9a9c-4be39c6f1aa2.png)
![Profit](https://user-images.githubusercontent.com/99198652/212372916-960472f5-f6f7-4a8f-b011-e4d4019897df.png)


PR also makes a minor fix to the `InformedTrader` which was not adhering to its configured `max_abs_position` and adds a `PriceSensitiveLimitOrderTrader` which places orders at a random offset from an external price (following an exponential distribution) with the intension of crossing the order book when the market maker is over exposed.

![SensitiveTraderProbability](https://user-images.githubusercontent.com/99198652/212367845-780f1909-dc3a-4f58-ab18-b806fe3491b4.png)

To run the example in console:
```
$ python -m vega_sim.scenario.adhoc -s parameter_experiment --console --pause
```
To run an example parameter test (all parameter tests to be updated with this scenario once merged):
```
$ python -m vega_sim.parameter_test.run -c StakeTargetScaling
```

### Testing
Passing all tests locally.

### Breaking Changes
None
