### PR TITLE
feat: parameter experiment updates

### DIFF
--- a/parameter_results/toolkit.py
+++ b/parameter_results/toolkit.py
@@ -223,8 +223,7 @@ class SingleParameterExperimentTk(NotebookTk):
         keys = list(product(variables, iterations))
 
         parameter_value_labels = [
-            f"{self.settings['parameter_tested']}={value}"
-            for value in self.settings["tested_values"]
+            f"param={value}" for value in self.settings["tested_values"]
         ]
         labels = [parameter_value_labels, [""], [""]]
 
@@ -308,8 +307,8 @@ class SingleParameterExperimentTk(NotebookTk):
         labels = [[""], [""], variables]
         labels_right = [[""], [""], variables_right]
 
-        cols = max(self.data_raw[0]["Iteration"]) + 1
-        rows = len(self.settings["tested_values"])
+        cols = len(iterations)
+        rows = len(parameters)
 
         fig, axs = plt.subplots(
             rows,
@@ -322,11 +321,18 @@ class SingleParameterExperimentTk(NotebookTk):
 
             for col in range(cols):
 
-                ax = axs[row, col]
+                if rows > 1 and cols > 1:
+                    ax = axs[row, col]
+                elif rows > 1:
+                    ax = axs[row]
+                elif cols > 1:
+                    ax = axs[col]
+                else:
+                    ax = axs
 
                 self._add_plot(
                     ax=ax,
-                    title=f"{self.settings['parameter_tested']}={parameters[row]} // iteration={iterations[col]}",
+                    title=f"param={parameters[row]} // iteration={iterations[col]}",
                     parameters=[parameters[row]],
                     iterations=[iterations[col]],
                     xlabel="Time",
@@ -500,7 +506,9 @@ class SingleParameterExperimentTk(NotebookTk):
         if self.settings["num_runs"] > 1:
             for _ in range(self.num_paravalues):
                 data_avg.append(
-                    self.data_raw[_].groupby(self.data_raw[_]["Time Step"]).mean()
+                    self.data_raw[_]
+                    .groupby(self.data_raw[_]["Time Step"])
+                    .mean(numeric_only=False)
                 )
         else:
             for _ in range(self.num_paravalues):

--- a/vega_sim/parameter_test/parameter/configs.py
+++ b/vega_sim/parameter_test/parameter/configs.py
@@ -2,14 +2,10 @@ from vega_sim.parameter_test.parameter.experiment import SingleParameterExperime
 from vega_sim.parameter_test.parameter.loggers import (
     ideal_market_maker_single_data_extraction,
     target_stake_additional_data,
-    v1_ideal_mm_additional_data,
     tau_scaling_additional_data,
     limit_order_book,
 )
-from vega_sim.scenario.configurable_market.scenario import ConfigurableMarket
-from vega_sim.scenario.curve_market_maker.scenario import CurveMarketMaker
 from vega_sim.scenario.parameter_experiment.scenario import ParameterExperiment
-from vega_sim.scenario.registry import IdealMarketMaker, IdealMarketMakerV2
 from vega_sim.parameter_test.parameter.loggers import (
     BASE_IDEAL_MM_CSV_HEADERS,
     LOB_CSV_HEADERS,
@@ -18,15 +14,12 @@ from vega_sim.parameter_test.parameter.experiment import (
     FILE_PATTERN,
     FILE_PATTERN_LOB,
 )
-from vega_sim.scenario.common.utils.price_process import (
-    Granularity,
-    get_historic_price_series,
-)
 
 TARGET_STAKE_SCALING_FACTOR = SingleParameterExperiment(
     name="TargetStakeScalingFactor",
-    parameter_to_vary="market.stake.target.scalingFactor",
-    values=["0.5", "5", "50"],
+    parameter_type="market",
+    parameter_to_vary="liquidity_monitoring_parameters.target_stake_parameters.scaling_factor",
+    values=[0.5, 5, 50],
     scenario=ParameterExperiment(
         state_extraction_fn=ideal_market_maker_single_data_extraction(
             additional_data_fns=[
@@ -37,75 +30,21 @@ TARGET_STAKE_SCALING_FACTOR = SingleParameterExperiment(
         ),
     ),
     runs_per_scenario=2,
-    additional_parameters_to_set=[
-        ("market.liquidity.targetstake.triggering.ratio", "1")
-    ],
+    additional_market_parameters_to_set={
+        "liquidity_monitoring_parameters.triggering_ratio": "1",
+    },
     data_extraction=[
         (FILE_PATTERN, BASE_IDEAL_MM_CSV_HEADERS),
         (FILE_PATTERN_LOB, LOB_CSV_HEADERS),
     ],
 )
 
-TAU_SCALING_FACTOR_IDEAL = SingleParameterExperiment(
-    name="TauScaling",
+TAU_SCALING_FACTOR = SingleParameterExperiment(
+    name="TauScalingFactor",
+    parameter_type="network",
     parameter_to_vary="market.liquidity.probabilityOfTrading.tau.scaling",
     values=["1", "10", "100"],
-    scenario=IdealMarketMaker(
-        num_steps=288,
-        market_decimal=3,
-        asset_decimal=5,
-        market_position_decimal=2,
-        spread=0.002,
-        initial_asset_mint=1e8,
-        lp_initial_mint=1e8,
-        lp_commitamount=50000,
-        initial_price=1123.11,
-        sigma=0.1,
-        kappa=50,
-        lambda_val=10,
-        q_upper=50,
-        q_lower=-50,
-        state_extraction_fn=ideal_market_maker_single_data_extraction(
-            additional_data_fns=[
-                v1_ideal_mm_additional_data,
-                tau_scaling_additional_data,
-                target_stake_additional_data,
-                limit_order_book,
-            ]
-        ),
-    ),
-    runs_per_scenario=2,
-    additional_parameters_to_set=[
-        ("market.liquidity.targetstake.triggering.ratio", "1")
-    ],
-    data_extraction=[
-        (FILE_PATTERN, BASE_IDEAL_MM_CSV_HEADERS),
-        (FILE_PATTERN_LOB, LOB_CSV_HEADERS),
-    ],
-)
-
-TARGET_STAKE_SCALING_FACTOR_IDEAL_v2 = SingleParameterExperiment(
-    name="StakeTargetScaling_v2",
-    parameter_to_vary="market.stake.target.scalingFactor",
-    values=["0.5", "5", "50"],
-    scenario=IdealMarketMakerV2(
-        market_decimal=3,
-        asset_decimal=5,
-        market_position_decimal=2,
-        initial_price=1123.11,
-        spread=4,
-        lp_commitamount=100000,
-        initial_asset_mint=1e8,
-        block_length_seconds=1,
-        buy_intensity=10,
-        sell_intensity=10,
-        q_upper=50,
-        q_lower=-50,
-        kappa=50,
-        sigma=0.1,
-        num_steps=288,
-        backgroundmarket_tick_spacing=0.002,
-        backgroundmarket_number_levels_per_side=20,
+    scenario=ParameterExperiment(
         state_extraction_fn=ideal_market_maker_single_data_extraction(
             additional_data_fns=[
                 tau_scaling_additional_data,
@@ -115,116 +54,21 @@ TARGET_STAKE_SCALING_FACTOR_IDEAL_v2 = SingleParameterExperiment(
         ),
     ),
     runs_per_scenario=2,
-    additional_parameters_to_set=[
-        ("market.liquidity.targetstake.triggering.ratio", "1")
-    ],
+    additional_market_parameters_to_set={
+        "liquidity_monitoring_parameters.triggering_ratio": "1",
+    },
     data_extraction=[
         (FILE_PATTERN, BASE_IDEAL_MM_CSV_HEADERS),
         (FILE_PATTERN_LOB, LOB_CSV_HEADERS),
     ],
 )
 
-TAU_SCALING_FACTOR_IDEAL_v2 = SingleParameterExperiment(
-    name="TauScaling_v2",
-    parameter_to_vary="market.liquidity.probabilityOfTrading.tau.scaling",
-    values=["1", "10", "100"],
-    scenario=IdealMarketMakerV2(
-        market_decimal=3,
-        asset_decimal=5,
-        market_position_decimal=2,
-        initial_price=1123.11,
-        spread=4,
-        lp_commitamount=100000,
-        initial_asset_mint=1e8,
-        block_length_seconds=1,
-        buy_intensity=10,
-        sell_intensity=10,
-        q_upper=50,
-        q_lower=-50,
-        kappa=50,
-        sigma=0.1,
-        num_steps=288,
-        backgroundmarket_tick_spacing=0.002,
-        backgroundmarket_number_levels_per_side=20,
-        state_extraction_fn=ideal_market_maker_single_data_extraction(
-            additional_data_fns=[
-                tau_scaling_additional_data,
-                target_stake_additional_data,
-                limit_order_book,
-            ]
-        ),
-    ),
-    runs_per_scenario=2,
-    additional_parameters_to_set=[
-        ("market.liquidity.targetstake.triggering.ratio", "1")
-    ],
-    data_extraction=[
-        (FILE_PATTERN, BASE_IDEAL_MM_CSV_HEADERS),
-        (FILE_PATTERN_LOB, LOB_CSV_HEADERS),
-    ],
-)
-
-BOND_PENALTY_FACTOR_IDEAL_v2 = SingleParameterExperiment(
-    name="BondPenalty_v2",
+BOND_PENALTY_PARAMETER = SingleParameterExperiment(
+    name="BondPenaltyFactor",
+    parameter_type="network",
     parameter_to_vary="market.liquidity.bondPenaltyParameter",
     values=["0.0", "0.5", "1.0"],
-    scenario=IdealMarketMakerV2(
-        market_decimal=3,
-        asset_decimal=5,
-        market_position_decimal=2,
-        initial_price=1123.11,
-        spread=0.002,
-        lp_commitamount=20000,
-        block_length_seconds=1,
-        buy_intensity=10,
-        sell_intensity=10,
-        q_upper=50,
-        q_lower=-50,
-        kappa=50,
-        sigma=0.5,
-        num_steps=72,
-        state_extraction_fn=ideal_market_maker_single_data_extraction(
-            additional_data_fns=[
-                tau_scaling_additional_data,
-                target_stake_additional_data,
-            ]
-        ),
-    ),
-    runs_per_scenario=2,
-    additional_parameters_to_set=[
-        ("market.liquidity.targetstake.triggering.ratio", "1")
-    ],
-)
-
-TAU_SCALING_FACTOR_IDEAL_CURVE = SingleParameterExperiment(
-    name="TauScaling_Curve",
-    parameter_to_vary="market.liquidity.probabilityOfTrading.tau.scaling",
-    values=["1", "10", "100"],
-    scenario=CurveMarketMaker(
-        market_name="ETH",
-        asset_name="USD",
-        num_steps=290,
-        market_decimal=2,
-        asset_decimal=4,
-        market_position_decimal=4,
-        # price_process_fn=lambda: get_historic_price_series(
-        #     product_id="ETH-USD", granularity=Granularity.HOUR
-        # ).values,
-        initial_price=1500,
-        lp_commitamount=250_000,
-        initial_asset_mint=10_000_000,
-        # step_length_seconds=60,
-        # step_length_seconds=Granularity.HOUR.value,
-        block_length_seconds=1,
-        buy_intensity=100,
-        sell_intensity=100,
-        q_upper=30,
-        q_lower=-30,
-        market_maker_curve_kappa=0.2,
-        market_maker_assumed_market_kappa=0.2,
-        sensitive_price_taker_half_life=20,
-        opening_auction_trade_amount=0.0001,
-        market_order_trader_base_order_size=0.01,
+    scenario=ParameterExperiment(
         state_extraction_fn=ideal_market_maker_single_data_extraction(
             additional_data_fns=[
                 tau_scaling_additional_data,
@@ -234,53 +78,18 @@ TAU_SCALING_FACTOR_IDEAL_CURVE = SingleParameterExperiment(
         ),
     ),
     runs_per_scenario=2,
-    additional_parameters_to_set=[
-        ("market.liquidity.targetstake.triggering.ratio", "1")
-    ],
+    additional_market_parameters_to_set={
+        "liquidity_monitoring_parameters.triggering_ratio": "1",
+    },
     data_extraction=[
         (FILE_PATTERN, BASE_IDEAL_MM_CSV_HEADERS),
         (FILE_PATTERN_LOB, LOB_CSV_HEADERS),
     ],
-)
-
-MARKET_PARAMETER_DEMO = SingleParameterExperiment(
-    name="MarketParameterDemo",
-    parameter_to_vary=(
-        "liquidity_monitoring_parameters.target_stake_parameters.scaling_factor"
-    ),
-    values=[1, 10, 100],
-    scenario=ConfigurableMarket(
-        market_name="RESEARCH: Ethereum:USD Q3 (Daily)",
-        market_code="ETH:USD",
-        asset_name="tUSD",
-        asset_dp=18,
-        num_steps=60,
-        state_extraction_fn=ideal_market_maker_single_data_extraction(
-            additional_data_fns=[
-                tau_scaling_additional_data,
-                target_stake_additional_data,
-                limit_order_book,
-            ]
-        ),
-    ),
-    runs_per_scenario=2,
-    additional_parameters_to_set=[
-        ("market.liquidity.targetstake.triggering.ratio", "1")
-    ],
-    data_extraction=[
-        (FILE_PATTERN, BASE_IDEAL_MM_CSV_HEADERS),
-        (FILE_PATTERN_LOB, LOB_CSV_HEADERS),
-    ],
-    market_parameter=True,
 )
 
 
 CONFIGS = [
     TARGET_STAKE_SCALING_FACTOR,
-    TAU_SCALING_FACTOR_IDEAL,
-    TAU_SCALING_FACTOR_IDEAL_v2,
-    TARGET_STAKE_SCALING_FACTOR_IDEAL_v2,
-    BOND_PENALTY_FACTOR_IDEAL_v2,
-    TAU_SCALING_FACTOR_IDEAL_CURVE,
-    MARKET_PARAMETER_DEMO,
+    TAU_SCALING_FACTOR,
+    BOND_PENALTY_PARAMETER,
 ]

--- a/vega_sim/parameter_test/parameter/experiment.py
+++ b/vega_sim/parameter_test/parameter/experiment.py
@@ -32,11 +32,13 @@ class Experiment:
 
 @dataclass
 class SingleParameterExperiment(Experiment):
+    parameter_type: str
     parameter_to_vary: str
     values: List[str]
     scenario: Scenario
     runs_per_scenario: int = 1
-    additional_parameters_to_set: Optional[Dict[str, str]] = None
+    additional_network_parameters_to_set: Optional[Dict[str, str]] = None
+    additional_market_parameters_to_set: Optional[Dict[str, str]] = None
     data_extraction: List[Tuple] = None
     market_parameter: Optional[bool] = False
 
@@ -47,16 +49,19 @@ class SingleParameterExperiment(Experiment):
             "tested_values": self.values,
             "scenario": self.scenario.__class__.__name__,
             "num_runs": self.runs_per_scenario,
-            "additional_parameters": self.additional_parameters_to_set,
+            "additional_network_parameters": self.additional_network_parameters_to_set,
+            "additional_market_parameters": self.additional_market_parameters_to_set,
             "data_extraction": self.data_extraction,
         }
 
 
 def _run_parameter_iteration(
+    parameter_type: str,
     scenario: Scenario,
     parameter_to_vary: str,
     value: str,
-    additional_parameters_to_set: Optional[Dict[str, str]] = None,
+    additional_network_parameters_to_set: Optional[Dict[str, str]] = None,
+    additional_market_parameters_to_set: Optional[Dict[str, str]] = None,
     random_state: Optional[np.random.RandomState] = None,
 ) -> Tuple[List[MarketHistoryData], Any]:
     with VegaServiceNull(
@@ -73,42 +78,31 @@ def _run_parameter_iteration(
             amount=1e4,
         )
 
-        if additional_parameters_to_set is not None:
-            for param, new_value in additional_parameters_to_set.items():
+        # Update additional network parameters and the parameter to vary if running a
+        # network parameter experiment.
+        if additional_network_parameters_to_set is not None:
+            for param, new_value in additional_network_parameters_to_set.items():
                 vega.update_network_parameter(
                     PARAMETER_AMEND_WALLET[0], parameter=param, new_value=new_value
                 )
+        if parameter_type == "network":
+            vega.update_network_parameter(
+                PARAMETER_AMEND_WALLET[0], parameter=parameter_to_vary, new_value=value
+            )
 
-        vega.update_network_parameter(
-            PARAMETER_AMEND_WALLET[0], parameter=parameter_to_vary, new_value=value
-        )
-
-        scenario.run_iteration(vega=vega, random_state=random_state)
-
-        return (scenario.get_run_data(), scenario.get_additional_run_data())
-
-
-def _run_market_parameter_iteration(
-    scenario: Scenario,
-    parameter_to_vary: str,
-    value: Union[str, int, float],
-    random_state: Optional[np.random.RandomState],
-) -> Tuple[List[MarketHistoryData], Any]:
-    with VegaServiceNull(
-        warn_on_raw_data_access=False,
-        retain_log_files=True,
-        run_with_console=False,
-        transactions_per_block=100,
-        use_full_vega_wallet=False,
-    ) as vega:
+        # Create the MarketObject using vega-sim defaults
         market_config = MarketConfig("default")
 
-        market_config.set(parameter_to_vary, value)
+        # Update additional market parameters and the parameter to vary if running a
+        # market parameter experiment
+        if additional_market_parameters_to_set is not None:
+            for param, new_value in additional_market_parameters_to_set.items():
+                market_config.set(parameter=param, value=new_value)
+        if parameter_type == "market":
+            market_config.set(parameter=parameter_to_vary, value=value)
 
         scenario.run_iteration(
-            vega=vega,
-            random_state=random_state,
-            market_config=market_config,
+            vega=vega, random_state=random_state, market_config=market_config
         )
 
         return (scenario.get_run_data(), scenario.get_additional_run_data())
@@ -124,20 +118,15 @@ def run_single_parameter_experiment(
     for value in experiment.values:
         results[value] = []
         for state in copy.deepcopy(random_seeds):
-            if experiment.market_parameter:
-                (_, res) = _run_market_parameter_iteration(
-                    scenario=experiment.scenario,
-                    parameter_to_vary=experiment.parameter_to_vary,
-                    value=value,
-                    random_state=state,
-                )
-            else:
-                (_, res) = _run_parameter_iteration(
-                    scenario=experiment.scenario,
-                    parameter_to_vary=experiment.parameter_to_vary,
-                    value=value,
-                    random_state=state,
-                )
+            (_, res) = _run_parameter_iteration(
+                parameter_type=experiment.parameter_type,
+                scenario=experiment.scenario,
+                parameter_to_vary=experiment.parameter_to_vary,
+                value=value,
+                random_state=state,
+                additional_network_parameters_to_set=experiment.additional_network_parameters_to_set,
+                additional_market_parameters_to_set=experiment.additional_market_parameters_to_set,
+            )
             results[value].append(res)
 
     return results


### PR DESCRIPTION
### Description
PR migrates all parameter experiments to use the new `ParameterExperiment` scenario. The parameter runner has also been updated to merge market parameter experiment runs and network parameter experiment runs into one method.

#### Updated Experiments

- `LiquidityTargetStakeScalingFactor` - renamed, scenario updated, and changed to a market parameter experiment
- `LiquidityTauScalingFactor` - renamed and scenario updated (kept as network parameter experiment)
- `LiquidityBondPenaltyFactor` - renamed and scenario updated (kept as network parameter experiment)


#### Deprecated Experiments

- `StakeTargetScaling_v2` - no need for duplicate “v2” experiment
- `TauScaling_v2` - no need for duplicate “v2” experiment
- `TauScaling_curve` - no need for duplicate “curve” experiment
- `MarketParameterDemo` - experiment adds no value in integration tests


### Testing
<!---
How has the change been tested? Were new unit/integration tests added and do current ones cover?
--->

### Breaking Changes
<!---
Are any of the changes in this PR breaking/requiring of a change in workflow?
--->

### Closes
<!---
Does this close any issues?
--->
