### PR TITLE
fix: drop rejected transfers

### DIFF
--- a/vega_sim/api/data.py
+++ b/vega_sim/api/data.py
@@ -1076,6 +1076,9 @@ def list_transfers(
     res_transfers = []
 
     for transfer in transfers:
+        if transfer.status == events_protos.Transfer.Status.STATUS_REJECTED:
+            continue
+
         if transfer.asset not in asset_dp:
             asset_dp[transfer.asset] = get_asset_decimals(
                 asset_id=transfer.asset, data_client=data_client

--- a/vega_sim/local_data_cache.py
+++ b/vega_sim/local_data_cache.py
@@ -350,7 +350,6 @@ class LocalDataCache:
                                 ][update.id] = update
 
                 elif isinstance(update, data.Transfer):
-                    print(update)
                     with self.transfers_lock:
                         self._transfer_state_from_feed.setdefault(update.party_to, {})[
                             update.id


### PR DESCRIPTION
### Description
Currently if a transfer is rejected for `reason: "could not transfer funds: asset does not exist"` ([example](https://api.n00.stagnet1.vega.xyz/api/v2/transfers)), market-sim will still attempt to find the information for the missing asset causing a crash.

PR simply updates `list_transfers` to drop rejected transfers.

### Testing
Passing all tests locally.

### Breaking Changes
None - rejected transfers are not used anywhere at the moment. May need to come back to this issue in the future.
