### PR TITLE
fix: no wallet required for console

### DIFF
--- a/vega_sim/null_service.py
+++ b/vega_sim/null_service.py
@@ -588,9 +588,7 @@ class VegaServiceNull(VegaService):
             else:
                 self._wallet = SlimWallet(
                     self.core_client,
-                    full_wallet=VegaWallet(self.wallet_url)
-                    if self.run_with_console
-                    else None,
+                    full_wallet=None,
                     log_dir=self.log_dir,
                 )
         return self._wallet
@@ -644,7 +642,7 @@ class VegaServiceNull(VegaService):
                 "port_config": port_config,
                 "transactions_per_block": self.transactions_per_block,
                 "block_duration": f"{int(self.seconds_per_block)}s",
-                "run_wallet": self._use_full_vega_wallet or self.run_with_console,
+                "run_wallet": self._use_full_vega_wallet,
                 "retain_log_files": self.retain_log_files,
                 "log_dir": self.log_dir,
                 "store_transactions": self.store_transactions,
@@ -670,7 +668,7 @@ class VegaServiceNull(VegaService):
                     requests.get(
                         f"http://localhost:{self.vega_node_rest_port}/blockchain/height"
                     ).raise_for_status()
-                    if self.run_with_console or self._use_full_vega_wallet:
+                    if self._use_full_vega_wallet:
                         requests.get(
                             f"http://localhost:{self.wallet_port}/api/v1/status"
                         ).raise_for_status()


### PR DESCRIPTION
### Description
Small change removing requirement to run a `SlimWallet` backed by a full `VegaWallet` when running with console.

Change needed to be able to run scenarios with a vega version greater than v0.68.0 due to wallet issues. Change means user will be unable to connect a wallet to console but this was already the case anyway.

### Testing
current tag - passing
develop tag - passing 

### Breaking Changes
`SlimWallet` not backed by `VegaWallet` when running on console.
