### PR TITLE
fix: set mm min valid price

### DIFF
--- a/vega_sim/scenario/common/agents.py
+++ b/vega_sim/scenario/common/agents.py
@@ -1590,6 +1590,7 @@ class ExponentialShapedMarketMaker(ShapedMarketMaker):
             base_price + mult_factor * self.num_levels * self.tick_spacing,
             mult_factor * self.tick_spacing,
         )
+        level_price[level_price < 1 / 10**self.mdp] = 1 / 10**self.mdp
 
         return [MMOrder(vol, price) for vol, price in zip(level_vol, level_price)]
 


### PR DESCRIPTION
### Description
PR updates the `ExponentialShapedMarketMaker` so orders below the minimum valid price are set to the minimum valid price.

### Testing
Passing all tests locally.

### Breaking Changes
None

### Closes
Closes #333 