### PR TITLE
fix: wait for total catchup

### DIFF
--- a/vega_sim/service.py
+++ b/vega_sim/service.py
@@ -340,9 +340,8 @@ class VegaService(ABC):
         )
 
         self.wait_fn(1)
-        self.wait_for_core_catchup()
+        self.wait_for_total_catchup()
         for i in range(500):
-            self.wait_fn(1)
             time.sleep(0.0005 * 1.01**i)
             post_acct = self.party_account(
                 wallet_name=wallet_name,
@@ -352,6 +351,7 @@ class VegaService(ABC):
             ).general
             if post_acct > curr_acct:
                 return
+            self.wait_fn(1)
 
         raise Exception(
             f"Failure minting asset {asset} for party {wallet_name}. Funds never"


### PR DESCRIPTION
### Description
After minting wait for total catchup to avoid slow datanode issues. Also moves `wait_fn` to the end of the loop to avoid too much unnecessary block forwarding outside of the environment loop (separate non-critical issue).


