### PR TITLE
fix: failing overnight runs

### DIFF
--- a/scripts/run-docker-fuzz-test.sh
+++ b/scripts/run-docker-fuzz-test.sh
@@ -6,8 +6,13 @@ WORK_DIR="$(realpath "$(dirname "$0")/..")"
 RESULT_DIR="${WORK_DIR}/test_logs/$(date '+%F_%H%M%S')-integration"
 mkdir -p "${RESULT_DIR}"
 
+docker rm fuzz_test || true
 docker run \
     --platform linux/amd64 \
+    --name fuzz_test \
     -v "${RESULT_DIR}:/tmp" \
     vega_sim_learning:latest \
-        python -m vega_sim.scenario.fuzzed_markets.run_fuzz_test --steps 2*60*24
+        python -m vega_sim.scenario.fuzzed_markets.run_fuzz_test --steps 2880
+
+docker cp fuzz_test:/vega_market_sim/fuzz_plots/. .
+docker rm fuzz_test

--- a/vega_sim/reinforcement/run_rl_agent.py
+++ b/vega_sim/reinforcement/run_rl_agent.py
@@ -1,3 +1,4 @@
+import time
 import argparse
 import logging
 import os
@@ -155,6 +156,9 @@ def _run(
                     # simulation of market to get some data
 
                     learning_agent.move_to_cpu()
+
+                    # Add time delay between iterations for threads to catch-up
+                    time.sleep(5)
 
                     _ = run_iteration(
                         learning_agent=learning_agent,

--- a/vega_sim/scenario/fuzzed_markets/run_fuzz_test.py
+++ b/vega_sim/scenario/fuzzed_markets/run_fuzz_test.py
@@ -1,3 +1,5 @@
+import os
+
 import logging
 import argparse
 
@@ -45,10 +47,12 @@ if __name__ == "__main__":
             output_data=True,
         )
 
+    os.mkdir("fuzz_plots")
+
     fuzz_figs = fuzz_plots()
     for key, fig in fuzz_figs.items():
-        fig.savefig(f"fuzz-{key}.jpg")
+        fig.savefig(f"fuzz_plots/fuzz-{key}.jpg")
 
     trading_figs = plot_run_outputs()
     for key, fig in trading_figs.items():
-        fig.savefig(f"trading-{key}.jpg")
+        fig.savefig(f"fuzz_plots/trading-{key}.jpg")


### PR DESCRIPTION
### Description

PR fixes incorrect `--steps` value in docker script and adds functionality to copy saved plots from the container to the host machine.

PR fixes up the RL tests failing for threads falling behind by adding a delay between iterations. The delay of `5s` adds an additional `40m` to the entire overnight run (assuming `500` iterations).

### Testing
Passing all tests.

### Breaking Changes
None

### Closes
None
