### PR TITLE
fix: No longer need 1e9 multiple

### DIFF
--- a/vega_sim/tools/scenario_output.py
+++ b/vega_sim/tools/scenario_output.py
@@ -211,6 +211,6 @@ def load_fuzzing_df(
     run_name = run_name if run_name is not None else DEFAULT_RUN_NAME
     df = pd.read_csv(os.path.join(output_path, run_name, FUZZING_FILE_NAME))
     if not df.empty:
-        df["time"] = pd.to_datetime(df.time * 1e9)
+        df["time"] = pd.to_datetime(df.time)
         df = df.set_index("time")
     return df


### PR DESCRIPTION
### Description
<!---
What is the change?
--->
Removing multiple from when timestamps were seconds

### Testing
<!---
How has the change been tested? Were new unit/integration tests added and do current ones cover?
--->
Integration tests only

### Breaking Changes
<!---
Are any of the changes in this PR breaking/requiring of a change in workflow?
--->

### Closes
<!---
Does this close any issues?
--->
