### PR TITLE
feat: thread catchup

### DIFF
--- a/vega_sim/environment/environment.py
+++ b/vega_sim/environment/environment.py
@@ -195,6 +195,9 @@ class MarketEnvironment:
             if self.transactions_per_block > 1:
                 vega.wait_fn(1)
 
+        # Wait for threads to catchup to ensure newly created market observed
+        vega.wait_for_thread_catchup()
+
         start_time = vega.get_blockchain_time(in_seconds=True)
         for i in range(self.n_steps):
             self.step(vega)

--- a/vega_sim/environment/environment.py
+++ b/vega_sim/environment/environment.py
@@ -363,7 +363,7 @@ class MarketEnvironmentWithState(MarketEnvironment):
         return VegaState(network_state=(), market_state=market_state)
 
     def step(self, vega: VegaService) -> None:
-        vega.wait_for_datanode_sync()
+        vega.wait_for_thread_catchup()
         state = self.state_func(vega)
         for agent in (
             sorted(self.agents, key=lambda _: self.random_state.random())

--- a/vega_sim/null_service.py
+++ b/vega_sim/null_service.py
@@ -760,6 +760,9 @@ class VegaServiceNull(VegaService):
                     "Timed out waiting for Vega simulator to start up"
                 )
 
+            # Create the data cache and start the live feeds
+            self.data_cache
+
         if self.run_with_console:
             webbrowser.open(f"http://localhost:{port_config[Ports.CONSOLE]}/", new=2)
 

--- a/vega_sim/service.py
+++ b/vega_sim/service.py
@@ -285,9 +285,7 @@ class VegaService(ABC):
     def wait_for_core_catchup(self) -> None:
         wait_for_core_catchup(self.core_client)
 
-    def wait_for_thread_catchup(
-        self, max_retries: int = 1000, threshold: float = 0.001
-    ):
+    def wait_for_thread_catchup(self, max_retries: int = 1000, threshold: float = 0.5):
         self.wait_for_datanode_sync()
         t0 = time.time()
         attempts = 0

--- a/vega_sim/service.py
+++ b/vega_sim/service.py
@@ -285,6 +285,23 @@ class VegaService(ABC):
     def wait_for_core_catchup(self) -> None:
         wait_for_core_catchup(self.core_client)
 
+    def wait_for_thread_catchup(
+        self, max_retries: int = 1000, threshold: float = 0.001
+    ):
+        self.wait_for_datanode_sync()
+        t0 = time.time()
+        attempts = 0
+        while attempts < max_retries:
+            attempts += 1
+            if self.get_blockchain_time() <= self.get_blockchain_time_from_feed():
+                break
+            time.sleep(0.001)
+        t_catchup = time.time() - t0
+        if t_catchup > threshold:
+            logging.warning(f"Thread catchup took {round(t_catchup, 2)}s.")
+        else:
+            logging.debug(f"Thread catchup took {round(t_catchup, 2)}s.")
+
     def wait_for_total_catchup(self) -> None:
         self.wait_for_core_catchup()
         self.wait_for_datanode_sync()
@@ -1457,6 +1474,9 @@ class VegaService(ABC):
         return data_raw.order_status(
             order_id=order_id, data_client=self.trading_data_client_v2, version=version
         )
+
+    def get_blockchain_time_from_feed(self):
+        return self.data_cache.time_update_from_feed()
 
     def order_status_from_feed(
         self, live_only: bool = True


### PR DESCRIPTION
### Description
PR adds functionality for waiting for observation threads to catch up and inserts a wait_for_thread_catchup call between the environment calls to individual `initialise` and step `methods` .

Change should prevent cases where agents attempt to reference markets which the thread has not yet observed.

### Testing
Passing all tests locally

### Breaking Changes
None

### Closes
None
