### PR TITLE
feat: Add gRPC readiness check to criteria on startup

### DIFF
--- a/vega_sim/local_data_cache.py
+++ b/vega_sim/local_data_cache.py
@@ -192,13 +192,13 @@ class LocalDataCache:
         self,
         asset_id: str,
     ) -> vega_protos.assets.Asset:
-        return self._asset_from_feed.get(asset_id, None)
+        return self._asset_from_feed[asset_id]
 
     def market_from_feed(
         self,
         market_id: str,
     ) -> vega_protos.markets.Market:
-        return self._market_from_feed.get(market_id, None)
+        return self._market_from_feed[market_id]
 
     def market_data_from_feed(
         self,
@@ -207,7 +207,7 @@ class LocalDataCache:
         """
         Output market info.
         """
-        return self.market_data_from_feed_store.get(market_id, None)
+        return self.market_data_from_feed_store[market_id]
 
     def order_status_from_feed(
         self, live_only: bool = True
@@ -379,15 +379,15 @@ class LocalDataCache:
             ]
         with self.market_data_lock:
             for market_id in market_ids:
-                self.market_data_from_feed_store[
-                    market_id
-                ] = data.get_latest_market_data(
-                    market_id,
-                    data_client=self._trading_data_client,
-                    market_price_decimals_map=self._market_price_decimals,
-                    market_position_decimals_map=self._market_pos_decimals,
-                    asset_decimals_map=self._asset_decimals,
-                    market_to_asset_map=self._market_to_asset,
+                self.market_data_from_feed_store[market_id] = (
+                    data.get_latest_market_data(
+                        market_id,
+                        data_client=self._trading_data_client,
+                        market_price_decimals_map=self._market_price_decimals,
+                        market_position_decimals_map=self._market_pos_decimals,
+                        asset_decimals_map=self._asset_decimals,
+                        market_to_asset_map=self._market_to_asset,
+                    )
                 )
 
     def initialise_transfer_monitoring(

--- a/vega_sim/local_data_cache.py
+++ b/vega_sim/local_data_cache.py
@@ -379,15 +379,15 @@ class LocalDataCache:
             ]
         with self.market_data_lock:
             for market_id in market_ids:
-                self.market_data_from_feed_store[market_id] = (
-                    data.get_latest_market_data(
-                        market_id,
-                        data_client=self._trading_data_client,
-                        market_price_decimals_map=self._market_price_decimals,
-                        market_position_decimals_map=self._market_pos_decimals,
-                        asset_decimals_map=self._asset_decimals,
-                        market_to_asset_map=self._market_to_asset,
-                    )
+                self.market_data_from_feed_store[
+                    market_id
+                ] = data.get_latest_market_data(
+                    market_id,
+                    data_client=self._trading_data_client,
+                    market_price_decimals_map=self._market_price_decimals,
+                    market_position_decimals_map=self._market_pos_decimals,
+                    asset_decimals_map=self._asset_decimals,
+                    market_to_asset_map=self._market_to_asset,
                 )
 
     def initialise_transfer_monitoring(

--- a/vega_sim/local_data_cache.py
+++ b/vega_sim/local_data_cache.py
@@ -383,15 +383,15 @@ class LocalDataCache:
             ]
         with self.market_data_lock:
             for market_id in market_ids:
-                self.market_data_from_feed_store[market_id] = (
-                    data.get_latest_market_data(
-                        market_id,
-                        data_client=self._trading_data_client,
-                        market_price_decimals_map=self._market_price_decimals,
-                        market_position_decimals_map=self._market_pos_decimals,
-                        asset_decimals_map=self._asset_decimals,
-                        market_to_asset_map=self._market_to_asset,
-                    )
+                self.market_data_from_feed_store[
+                    market_id
+                ] = data.get_latest_market_data(
+                    market_id,
+                    data_client=self._trading_data_client,
+                    market_price_decimals_map=self._market_price_decimals,
+                    market_position_decimals_map=self._market_pos_decimals,
+                    asset_decimals_map=self._asset_decimals,
+                    market_to_asset_map=self._market_to_asset,
                 )
 
     def initialise_transfer_monitoring(

--- a/vega_sim/local_data_cache.py
+++ b/vega_sim/local_data_cache.py
@@ -192,12 +192,16 @@ class LocalDataCache:
         self,
         asset_id: str,
     ) -> vega_protos.assets.Asset:
+        if asset_id not in self._asset_from_feed:
+            self.initialise_assets()
         return self._asset_from_feed[asset_id]
 
     def market_from_feed(
         self,
         market_id: str,
     ) -> vega_protos.markets.Market:
+        if market_id not in self._market_from_feed:
+            self.initialise_markets()
         return self._market_from_feed[market_id]
 
     def market_data_from_feed(
@@ -379,15 +383,15 @@ class LocalDataCache:
             ]
         with self.market_data_lock:
             for market_id in market_ids:
-                self.market_data_from_feed_store[
-                    market_id
-                ] = data.get_latest_market_data(
-                    market_id,
-                    data_client=self._trading_data_client,
-                    market_price_decimals_map=self._market_price_decimals,
-                    market_position_decimals_map=self._market_pos_decimals,
-                    asset_decimals_map=self._asset_decimals,
-                    market_to_asset_map=self._market_to_asset,
+                self.market_data_from_feed_store[market_id] = (
+                    data.get_latest_market_data(
+                        market_id,
+                        data_client=self._trading_data_client,
+                        market_price_decimals_map=self._market_price_decimals,
+                        market_position_decimals_map=self._market_pos_decimals,
+                        asset_decimals_map=self._asset_decimals,
+                        market_to_asset_map=self._market_to_asset,
+                    )
                 )
 
     def initialise_transfer_monitoring(

--- a/vega_sim/null_service.py
+++ b/vega_sim/null_service.py
@@ -780,6 +780,7 @@ class VegaServiceNull(VegaService):
             # Create a block before waiting for datanode sync and starting the feeds
             self.wait_fn(1)
             self.wait_for_total_catchup()
+            self.wait_for_thread_catchup()
             self.data_cache
 
         if self.run_with_console:

--- a/vega_sim/null_service.py
+++ b/vega_sim/null_service.py
@@ -779,7 +779,7 @@ class VegaServiceNull(VegaService):
 
             # Create a block before waiting for datanode sync and starting the feeds
             self.wait_fn(1)
-            self.wait_for_datanode_sync()
+            self.wait_for_total_catchup()
             self.data_cache
 
         if self.run_with_console:

--- a/vega_sim/null_service.py
+++ b/vega_sim/null_service.py
@@ -743,7 +743,7 @@ class VegaServiceNull(VegaService):
                         self.data_node_grpc_url,
                         options=(("grpc.enable_http_proxy", 0),),
                     )
-                    grpc.channel_ready_future(channel).result(timeout=30)
+                    grpc.channel_ready_future(channel).result(timeout=5)
                     trading_data_client = vac.VegaTradingDataClientV2(
                         self.data_node_grpc_url,
                         channel=channel,
@@ -768,9 +768,11 @@ class VegaServiceNull(VegaService):
                     requests.exceptions.ConnectionError,
                     requests.exceptions.HTTPError,
                     grpc.RpcError,
+                    grpc.FutureTimeoutError,
                 ):
                     time.sleep(0.1)
             if not started:
+                self.stop()
                 raise VegaStartupTimeoutError(
                     "Timed out waiting for Vega simulator to start up"
                 )

--- a/vega_sim/service.py
+++ b/vega_sim/service.py
@@ -190,6 +190,7 @@ class VegaService(ABC):
     @property
     def data_cache(self) -> LocalDataCache:
         if self._local_data_cache is None:
+            self.wait_for_total_catchup()
             self._local_data_cache = LocalDataCache(
                 self.trading_data_client_v2,
                 self.trading_data_client_v2,


### PR DESCRIPTION
### Description
<!---
What is the change?
--->
Adding a check for gRPC readiness specifically as it seems REST was returning before gRPC was returning valid values from datanode

### Testing
<!---
How has the change been tested? Were new unit/integration tests added and do current ones cover?
--->
Tried a couple of tests, all worked fine, will observe output of full run.

### Breaking Changes
<!---
Are any of the changes in this PR breaking/requiring of a change in workflow?
--->

### Closes
<!---
Does this close any issues?
--->
