### PR TITLE
feat: add reduce and post only flags

### DIFF
--- a/vega_sim/api/trading.py
+++ b/vega_sim/api/trading.py
@@ -51,6 +51,8 @@ def submit_order(
     time_forward_fn: Optional[Callable[[], None]] = None,
     order_ref: Optional[str] = None,
     key_name: Optional[str] = None,
+    reduce_only: bool = False,
+    post_only: bool = False,
 ) -> Optional[str]:
     """
     Submit orders as specified to required pre-existing market.
@@ -97,6 +99,10 @@ def submit_order(
             optional str, reference for later identification of order
         key_name:
             Optional[str], key name stored in metadata. Defaults to None.
+        reduce_only:
+            bool, whether the order should only reduce a parties position.
+        post_only:
+            bool, whether an order should be prevented from trading immediately.
 
     Returns:
         Optional[str], Order ID if wait is True, otherwise None
@@ -113,6 +119,8 @@ def submit_order(
         reference=order_ref,
         price=price,
         pegged_order=pegged_order,
+        reduce_only=reduce_only,
+        post_only=post_only,
     )
 
     # Sign the transaction with an order submission command
@@ -509,6 +517,8 @@ def order_submission(
     reference: Optional[str] = None,
     price: Optional[str] = None,
     pegged_order: Optional[Union[vega_protos.PeggedOrder, str]] = None,
+    reduce_only: bool = False,
+    post_only: bool = False,
 ) -> OrderSubmission:
     """Creates a Vega OrderSubmission object.
 
@@ -534,6 +544,10 @@ def order_submission(
             Price to place order at, only required for "TYPE_LIMIT". Defaults to None.
         pegged_order (Optional[Union[vega_protos.PeggedOrder, str]]):
             PeggedOrder object defining whether order is pegged. Defaults to None.
+        reduce_only (bool):
+            Whether the order should only reduce a parties position. Defaults to False.
+        post_only (bool):
+            Whether order should be prevented trading immediately. Defaults to False.
 
     Returns:
         OrderSubmission:
@@ -563,6 +577,8 @@ def order_submission(
         side=side,
         time_in_force=time_in_force,
         type=order_type,
+        reduce_only=reduce_only,
+        post_only=post_only,
     )
 
     # Update OrderSubmission object with optional fields if specified

--- a/vega_sim/scenario/fuzzed_markets/agents.py
+++ b/vega_sim/scenario/fuzzed_markets/agents.py
@@ -22,6 +22,8 @@ class FuzzingAgent(StateAgentWithWallet):
             "SIDE",
             "TIME_IN_FORCE",
             "PEGGED_REFERENCE",
+            "POST_ONLY",
+            "REDUCE_ONLY",
         )
     }
     # Set the output flag which all instances can modify
@@ -188,6 +190,22 @@ class FuzzingAgent(StateAgentWithWallet):
                 p=[0.5, 0.5 / 3, 0.5 / 3, 0.5 / 3],
             )
         )
+        FuzzingAgent.MEMORY["REDUCE_ONLY"].append(
+            self.random_state.choice(
+                a=[
+                    True,
+                    False,
+                ],
+            )
+        )
+        FuzzingAgent.MEMORY["POST_ONLY"].append(
+            self.random_state.choice(
+                a=[
+                    True,
+                    False,
+                ],
+            )
+        )
 
         return self.vega.create_order_submission(
             market_id=self.market_id,
@@ -204,6 +222,8 @@ class FuzzingAgent(StateAgentWithWallet):
             ),
             pegged_reference=FuzzingAgent.MEMORY["PEGGED_REFERENCE"][-1],
             pegged_offset=self.random_state.normal(loc=0, scale=10),
+            reduce_only=FuzzingAgent.MEMORY["REDUCE_ONLY"][-1],
+            post_only=FuzzingAgent.MEMORY["POST_ONLY"][-1],
         )
 
     def _select_order_id(self):

--- a/vega_sim/service.py
+++ b/vega_sim/service.py
@@ -565,6 +565,8 @@ class VegaService(ABC):
         wait: bool = True,
         order_ref: Optional[str] = None,
         trading_wallet: Optional[str] = None,
+        reduce_only: bool = False,
+        post_only: bool = False,
     ) -> str:
         """Places a simple Market order, either as Fill-Or-Kill or Immediate-Or-Cancel.
 
@@ -584,6 +586,12 @@ class VegaService(ABC):
                 optional str, reference for later identification of order
             wallet_name:
                 optional str, name of wallet to use
+            reduce_only (bool):
+                Whether the order should only reduce a parties position. Defaults to
+                False.
+            post_only (bool):
+                Whether order should be prevented from trading immediately. Defaults to
+                False.
 
         Returns:
             str, The ID of the order
@@ -599,6 +607,8 @@ class VegaService(ABC):
             wait=wait,
             order_ref=order_ref,
             trading_key=trading_key,
+            reduce_only=reduce_only,
+            post_only=post_only,
         )
 
     def submit_order(
@@ -615,6 +625,8 @@ class VegaService(ABC):
         wait: bool = True,
         order_ref: Optional[str] = None,
         trading_wallet: Optional[str] = None,
+        reduce_only: bool = False,
+        post_only: bool = False,
     ) -> Optional[str]:
         """
         Submit orders as specified to required pre-existing market.
@@ -652,6 +664,12 @@ class VegaService(ABC):
                 optional str, reference for later identification of order
             key_name:
                 optional str, name of key in wallet to use
+            reduce_only (bool):
+                Whether the order should only reduce a parties position. Defaults to
+                False.
+            post_only (bool):
+                Whether order should be prevented from trading immediately. Defaults to
+                False.
 
         Returns:
             Optional[str], If order acceptance is waited for, returns order ID.
@@ -712,6 +730,8 @@ class VegaService(ABC):
             time_forward_fn=lambda: self.wait_fn(2),
             order_ref=order_ref,
             key_name=trading_key,
+            reduce_only=reduce_only,
+            post_only=post_only,
         )
 
     def get_blockchain_time(self, in_seconds: bool = False) -> int:
@@ -1825,6 +1845,8 @@ class VegaService(ABC):
         reference: Optional[str] = None,
         pegged_reference: Optional[str] = None,
         pegged_offset: Optional[float] = None,
+        reduce_only: bool = False,
+        post_only: bool = False,
     ) -> OrderSubmission:
         """Returns a Vega OrderSubmission object
 
@@ -1853,6 +1875,12 @@ class VegaService(ABC):
                 Reference for price offset for order. Defaults to None.
             pegged_offset (Optional[float]):
                 Value for price offset from reference for order. Defaults to None.
+            reduce_only (bool):
+                Whether the order should only reduce a parties position. Defaults to
+                False.
+            post_only (bool):
+                Whether order should be prevented from trading immediately. Defaults to
+                False.
 
         Returns:
             OrderSubmission:
@@ -1913,6 +1941,8 @@ class VegaService(ABC):
             order_type=order_type,
             reference=reference,
             pegged_order=pegged_order,
+            reduce_only=reduce_only,
+            post_only=post_only,
         )
 
     def submit_instructions(


### PR DESCRIPTION
### Description
Adds `reduce_only` and `post_only` flags to all submit order methods. Both default too `False`.

Updates the `FuzzingAgent` to randomly use these flags.

### Testing
Passing all tests locally.

### Breaking Changes
None (flags default to `False`).

### Closes
#383 
