### PR TITLE
feat: add account balance plots

### DIFF
--- a/vega_sim/environment/agent.py
+++ b/vega_sim/environment/agent.py
@@ -81,6 +81,9 @@ class AgentWithWallet(Agent):
                 wallet_name=self.wallet_name,
                 name=self.key_name,
             )
+            self._public_key = vega.wallet.public_key(
+                name=self.key_name, wallet_name=self.wallet_name
+            )
 
 
 class StateAgentWithWallet(AgentWithWallet):

--- a/vega_sim/scenario/fuzzed_markets/agents.py
+++ b/vega_sim/scenario/fuzzed_markets/agents.py
@@ -337,6 +337,7 @@ class DegenerateTrader(StateAgentWithWallet):
                 asset=self.asset_id,
             )
             self.close_outs += 1
+            self.commitment_amount = 0
             return
 
         if (
@@ -438,6 +439,7 @@ class DegenerateLiquidityProvider(StateAgentWithWallet):
                 asset=self.asset_id,
             )
             self.close_outs += 1
+            self.commitment_amount = 0
             return
 
         if self.random_state.rand() > self.step_bias:

--- a/vega_sim/scenario/fuzzed_markets/run_fuzz_test.py
+++ b/vega_sim/scenario/fuzzed_markets/run_fuzz_test.py
@@ -8,7 +8,7 @@ from vega_sim.null_service import VegaServiceNull
 from vega_sim.scenario.constants import Network
 from vega_sim.scenario.fuzzed_markets.scenario import FuzzingScenario
 
-from vega_sim.tools.scenario_plots import fuzz_plots, plot_run_outputs
+from vega_sim.tools.scenario_plots import fuzz_plots, plot_run_outputs, account_plots
 
 
 def _run(steps: int = 2880, output: bool = False):
@@ -45,6 +45,9 @@ def _run(steps: int = 2880, output: bool = False):
         trading_figs = plot_run_outputs()
         for key, fig in trading_figs.items():
             fig.savefig(f"fuzz_plots/trading-{key}.jpg")
+
+        account_fig = account_plots()
+        account_fig.savefig(f"fuzz_plots/accounts-{key}.jpg")
 
 
 if __name__ == "__main__":

--- a/vega_sim/scenario/scenario.py
+++ b/vega_sim/scenario/scenario.py
@@ -6,7 +6,10 @@ from vega_sim.null_service import VegaService
 from vega_sim.environment.environment import MarketEnvironment
 from vega_sim.scenario.constants import Network
 from vega_sim.scenario.common.agents import Snitch, StateAgent, MarketHistoryData, Agent
-from vega_sim.tools.scenario_output import market_data_standard_output
+from vega_sim.tools.scenario_output import (
+    market_data_standard_output,
+    agents_standard_output,
+)
 
 
 class Scenario(abc.ABC):
@@ -85,6 +88,7 @@ class Scenario(abc.ABC):
             log_every_n_steps=log_every_n_steps,
         )
         if output_data:
+            agents_standard_output(self.agents)
             market_data_standard_output(self.get_run_data())
             if self.additional_data_output_fns is not None:
                 market_data_standard_output(
@@ -96,6 +100,10 @@ class Scenario(abc.ABC):
 
     def get_snitch(self) -> Optional[Snitch]:
         return self.agents.get("snitch")
+
+    def get_agents(self) -> dict:
+        snitch = self.get_snitch()
+        return snitch.agents if snitch is not None else {}
 
     def get_run_data(self) -> List[MarketHistoryData]:
         snitch = self.get_snitch()

--- a/vega_sim/scenario/scenario.py
+++ b/vega_sim/scenario/scenario.py
@@ -101,10 +101,6 @@ class Scenario(abc.ABC):
     def get_snitch(self) -> Optional[Snitch]:
         return self.agents.get("snitch")
 
-    def get_agents(self) -> dict:
-        snitch = self.get_snitch()
-        return snitch.agents if snitch is not None else {}
-
     def get_run_data(self) -> List[MarketHistoryData]:
         snitch = self.get_snitch()
         return snitch.states if snitch is not None else []

--- a/vega_sim/tools/scenario_output.py
+++ b/vega_sim/tools/scenario_output.py
@@ -1,3 +1,4 @@
+from vega_sim.environment.agent import Agent, StateAgentWithWallet
 from vega_sim.scenario.common.agents import MarketHistoryData
 from typing import List, Callable, Optional, Dict
 import pandas as pd
@@ -8,6 +9,7 @@ import os.path
 DEFAULT_PATH = "./run_logs"
 DEFAULT_RUN_NAME = "latest"
 
+AGENTS_FILE_NAME = "agents.csv"
 DATA_FILE_NAME = "market_data.csv"
 ORDER_BOOK_FILE_NAME = "depth_data.csv"
 TRADES_FILE_NAME = "trades.csv"
@@ -152,6 +154,38 @@ def market_data_standard_output(
             output_path=full_path,
             data_to_row_fn=data_fn,
         )
+
+
+def agents_standard_output(
+    agents: Dict[str, Agent],
+    run_name: str = DEFAULT_RUN_NAME,
+    output_path: str = DEFAULT_PATH,
+):
+    results = {
+        key: [] for key in ["agent_name", "agent_type", "agent_tag", "agent_key"]
+    }
+    for name, agent in agents.items():
+        results["agent_name"].append(name)
+        results["agent_tag"].append(agent.tag)
+        results["agent_type"].append(type(agent).__name__)
+        if isinstance(agent, StateAgentWithWallet):
+            results["agent_key"].append(agent._public_key)
+        else:
+            results["agent_key"].append(None)
+
+    full_path = os.path.join(output_path, run_name)
+    os.makedirs(full_path, exist_ok=True)
+    pd.DataFrame.from_dict(results).to_csv(os.path.join(full_path, AGENTS_FILE_NAME))
+
+
+def load_agents_df(
+    run_name: Optional[str] = None,
+    output_path: str = DEFAULT_PATH,
+) -> pd.DataFrame:
+    run_name = run_name if run_name is not None else DEFAULT_RUN_NAME
+    return pd.read_csv(os.path.join(output_path, run_name, AGENTS_FILE_NAME)).set_index(
+        "agent_name"
+    )
 
 
 def load_market_data_df(

--- a/vega_sim/tools/scenario_plots.py
+++ b/vega_sim/tools/scenario_plots.py
@@ -563,7 +563,7 @@ def account_plots(run_name: Optional[str] = None, agent_types: Optional[list] = 
             )
             axs[i].plot(totals)
         axs[i].autoscale(enable=True, axis="y")
-        
+
     return fig
 
 

--- a/vega_sim/tools/scenario_plots.py
+++ b/vega_sim/tools/scenario_plots.py
@@ -562,18 +562,17 @@ def account_plots(run_name: Optional[str] = None, agent_types: Optional[list] = 
                 .sum()
             )
             axs[i].plot(totals)
-        # axs[i].set_ylim(bottom=0)
         axs[i].autoscale(enable=True, axis="y")
-
+        
     return fig
 
 
 if __name__ == "__main__":
-    # figs = fuzz_plots()
-    # for key, fig in figs.items():
-    #     fig.savefig(f"fuzz-{key}.jpg")
-    # figs = plot_run_outputs()
-    # for key, fig in figs.items():
-    #     fig.savefig(f"rl-{key}.jpg")
-    figs = account_plots()
-    plt.show()
+    figs = fuzz_plots()
+    for key, fig in figs.items():
+        fig.savefig(f"fuzz-{key}.jpg")
+    figs = plot_run_outputs()
+    for key, fig in figs.items():
+        fig.savefig(f"rl-{key}.jpg")
+    fig = account_plots()
+    fig.savefig(f"accounts.jpg")

--- a/vega_sim/tools/scenario_plots.py
+++ b/vega_sim/tools/scenario_plots.py
@@ -8,6 +8,13 @@ from matplotlib.figure import Figure
 from matplotlib.markers import MarkerStyle
 from matplotlib.gridspec import GridSpec, SubplotSpec, GridSpecFromSubplotSpec
 
+from vega_sim.scenario.fuzzed_markets.agents import (
+    FuzzingAgent,
+    FuzzyLiquidityProvider,
+    DegenerateTrader,
+    DegenerateLiquidityProvider,
+)
+
 from vega_sim.proto.vega import markets
 
 import numpy as np
@@ -35,6 +42,7 @@ from vega_sim.tools.scenario_output import (
     load_order_book_df,
     load_trades_df,
     load_fuzzing_df,
+    load_agents_df,
 )
 
 
@@ -508,10 +516,64 @@ def fuzz_plots(run_name: Optional[str] = None) -> Figure:
     return figs
 
 
+def account_plots(run_name: Optional[str] = None, agent_types: Optional[list] = None):
+    accounts_df = load_accounts_df(run_name=run_name)
+    agents_df = load_agents_df(run_name=run_name)
+
+    fig = plt.figure(figsize=[8, 10])
+    fig.suptitle(
+        f"Agent Account Plots",
+        fontsize=18,
+        fontweight="bold",
+        color=(0.2, 0.2, 0.2),
+    )
+    fig.tight_layout()
+
+    plt.rcParams.update({"font.size": 8})
+
+    agent_types = [
+        FuzzingAgent,
+        FuzzyLiquidityProvider,
+        DegenerateTrader,
+        DegenerateLiquidityProvider,
+    ]
+
+    gs = GridSpec(nrows=len(agent_types), ncols=1, hspace=0.5)
+
+    axs: list[plt.Axes] = []
+
+    for i, agent_type in enumerate(agent_types):
+        axs.append(fig.add_subplot(gs[i, 0]))
+
+        axs[i].set_title(
+            f"Total Account Balance: {agent_type.__name__}",
+            loc="left",
+            fontsize=12,
+            color=(0.3, 0.3, 0.3),
+        )
+
+        agent_keys = agents_df["agent_key"][
+            agents_df["agent_type"] == agent_type.__name__
+        ].to_list()
+        for key in agent_keys:
+            totals = (
+                accounts_df[accounts_df["party_id"] == key]["balance"]
+                .groupby(level=0)
+                .sum()
+            )
+            axs[i].plot(totals)
+        # axs[i].set_ylim(bottom=0)
+        axs[i].autoscale(enable=True, axis="y")
+
+    return fig
+
+
 if __name__ == "__main__":
-    figs = fuzz_plots()
-    for key, fig in figs.items():
-        fig.savefig(f"fuzz-{key}.jpg")
-    figs = plot_run_outputs()
-    for key, fig in figs.items():
-        fig.savefig(f"rl-{key}.jpg")
+    # figs = fuzz_plots()
+    # for key, fig in figs.items():
+    #     fig.savefig(f"fuzz-{key}.jpg")
+    # figs = plot_run_outputs()
+    # for key, fig in figs.items():
+    #     fig.savefig(f"rl-{key}.jpg")
+    figs = account_plots()
+    plt.show()


### PR DESCRIPTION
### Description

PR adds functionality to the `Scenario` to get the dictionary of agents stored in the `Snitch` as well as methods for storing agent information in a `.csv` post run.

The `.csv` file maps agent keys to agent types, tags, and names.

PR also adds tools for plotting account history by agent type.
![accounts-c71e76cf9b8ee91e265c0d2387f3652abc6ae15d5ffeec731ca9a32bed0eda8a](https://user-images.githubusercontent.com/99198652/231506595-1744f5cd-56b6-484c-849d-a64e4ea20a66.jpg)

### Testing

### Breaking Changes

### Closes

