### PR TITLE
feat: Reducing max faucet amount in market manager created assets

### DIFF
--- a/vega_sim/scenario/configurable_market/agents.py
+++ b/vega_sim/scenario/configurable_market/agents.py
@@ -92,7 +92,7 @@ class ConfigurableMarketManager(StateAgentWithWallet):
                 name=self.asset_name,
                 symbol=self.asset_name,
                 decimals=self.asset_dp,
-                max_faucet_amount=1e30,
+                max_faucet_amount=10_000_000_000,
                 key_name=self.key_name,
             )
 


### PR DESCRIPTION
### Description
<!---
What is the change?
--->
Reducing max faucet amount. Believe we hit a limit when it is too high as the amount increases each time a faucet happens.

### Testing
<!---
How has the change been tested? Were new unit/integration tests added and do current ones cover?
--->
Ran locally, appeared to resolve issues of bots becoming unable to faucet

### Breaking Changes
<!---
Are any of the changes in this PR breaking/requiring of a change in workflow?
--->

### Closes
<!---
Does this close any issues?
--->
