### PR TITLE
feat: add price variation to fuzz test

### DIFF
--- a/vega_sim/api/data.py
+++ b/vega_sim/api/data.py
@@ -510,10 +510,10 @@ def _market_data_from_proto(
         auction_end=market_data.auction_end,
         auction_start=market_data.auction_start,
         indicative_price=num_from_padded_int(
-            market_data.static_mid_price, decimal_spec.price_decimals
+            market_data.indicative_price, decimal_spec.price_decimals
         ),
         indicative_volume=num_from_padded_int(
-            market_data.static_mid_price, decimal_spec.price_decimals
+            market_data.indicative_volume, decimal_spec.price_decimals
         ),
         market_trading_mode=market_data.market_trading_mode,
         trigger=market_data.trigger,

--- a/vega_sim/scenario/fuzzed_markets/run_fuzz_test.py
+++ b/vega_sim/scenario/fuzzed_markets/run_fuzz_test.py
@@ -8,8 +8,9 @@ from vega_sim.null_service import VegaServiceNull
 from vega_sim.scenario.constants import Network
 from vega_sim.scenario.fuzzed_markets.scenario import FuzzingScenario
 
-from vega_sim.tools.scenario_plots import fuzz_plots, plot_run_outputs, account_plots
+from vega_sim.tools.scenario_plots import fuzz_plots, plot_run_outputs, account_plots, plot_price_monitoring
 
+from matplotlib import pyplot as plt
 
 def _run(steps: int = 2880, output: bool = False):
     scenario = FuzzingScenario(
@@ -38,16 +39,24 @@ def _run(steps: int = 2880, output: bool = False):
         if not os.path.exists("fuzz_plots"):
             os.mkdir("fuzz_plots")
 
+        fuzz_figs = plot_price_monitoring()
+        for key, fig in fuzz_figs.items():
+            fig.savefig(f"fuzz_plots/monitoring-{key}.jpg")
+            plt.close(fig)
+
         fuzz_figs = fuzz_plots()
         for key, fig in fuzz_figs.items():
             fig.savefig(f"fuzz_plots/fuzz-{key}.jpg")
+            plt.close(fig)
 
         trading_figs = plot_run_outputs()
         for key, fig in trading_figs.items():
             fig.savefig(f"fuzz_plots/trading-{key}.jpg")
+            plt.close(fig)
 
         account_fig = account_plots()
         account_fig.savefig(f"fuzz_plots/accounts-{key}.jpg")
+        plt.close(account_fig)
 
 
 if __name__ == "__main__":

--- a/vega_sim/scenario/fuzzed_markets/run_fuzz_test.py
+++ b/vega_sim/scenario/fuzzed_markets/run_fuzz_test.py
@@ -8,9 +8,15 @@ from vega_sim.null_service import VegaServiceNull
 from vega_sim.scenario.constants import Network
 from vega_sim.scenario.fuzzed_markets.scenario import FuzzingScenario
 
-from vega_sim.tools.scenario_plots import fuzz_plots, plot_run_outputs, account_plots, plot_price_monitoring
+from vega_sim.tools.scenario_plots import (
+    fuzz_plots,
+    plot_run_outputs,
+    account_plots,
+    plot_price_monitoring,
+)
 
 from matplotlib import pyplot as plt
+
 
 def _run(steps: int = 2880, output: bool = False):
     scenario = FuzzingScenario(

--- a/vega_sim/scenario/fuzzed_markets/scenario.py
+++ b/vega_sim/scenario/fuzzed_markets/scenario.py
@@ -13,9 +13,10 @@ from vega_sim.null_service import VegaServiceNull
 from vega_sim.scenario.configurable_market.agents import ConfigurableMarketManager
 from vega_sim.scenario.common.agents import (
     StateAgent,
-    OpenAuctionPass,
+    UncrossAuctionAgent,
     ExponentialShapedMarketMaker,
     MarketOrderTrader,
+    LimitOrderTrader,
 )
 from vega_sim.scenario.fuzzed_markets.agents import (
     FuzzingAgent,
@@ -95,7 +96,7 @@ def _create_price_process(
                 price_process,
                 random_walk(
                     num_steps=random_state.randint(
-                        int(0.10 * num_steps), int(0.4 * num_steps)
+                        int(0.05 * num_steps), int(0.20 * num_steps)
                     ),
                     sigma=2,
                     starting_price=price_process[-1],
@@ -103,13 +104,13 @@ def _create_price_process(
                 ),
             )
         )
-        # Add an unstable price-process with a random duration of 1-5% of the sim
+        # Add an unstable price-process with a random duration of 5-10% of the sim
         price_process = np.concatenate(
             (
                 price_process,
                 random_walk(
                     num_steps=random_state.randint(
-                        int(0.01 * num_steps), int(0.1 * num_steps)
+                        int(0.05 * num_steps), int(0.10 * num_steps)
                     ),
                     sigma=2,
                     drift=random_state.uniform(-1, 1),
@@ -230,9 +231,9 @@ class FuzzingScenario(Scenario):
                     market_decimal_places=market_config.decimal_places,
                     asset_decimal_places=asset_name,
                     num_steps=self.num_steps,
-                    kappa=0.6,
-                    tick_spacing=0.1,
-                    market_kappa=20,
+                    kappa=2.4,
+                    tick_spacing=0.05,
+                    market_kappa=50,
                     state_update_freq=10,
                     tag=f"MARKET_{str(i_market).zfill(3)}",
                 )
@@ -240,15 +241,15 @@ class FuzzingScenario(Scenario):
 
             for i_agent, side in enumerate(["SIDE_BUY", "SIDE_SELL"]):
                 auction_traders.append(
-                    OpenAuctionPass(
+                    UncrossAuctionAgent(
                         wallet_name=f"AUCTION_TRADERS",
                         key_name=f"MARKET_{str(i_market).zfill(3)}_{side}",
                         side=side,
                         initial_asset_mint=self.initial_asset_mint,
-                        initial_price=price_process[0],
+                        price_process=iter(price_process),
                         market_name=market_name,
                         asset_name=asset_name,
-                        opening_auction_trade_amount=1,
+                        uncrossing_size=20,
                         tag=f"MARKET_{str(i_market).zfill(3)}_AGENT_{str(i_agent).zfill(3)}",
                     )
                 )
@@ -264,6 +265,29 @@ class FuzzingScenario(Scenario):
                         sell_intensity=10,
                         base_order_size=1,
                         step_bias=1,
+                        tag=f"MARKET_{str(i_market).zfill(3)}_AGENT_{str(i_agent).zfill(3)}",
+                    )
+                )
+
+            for i_agent in range(5):
+                random_traders.append(
+                    LimitOrderTrader(
+                        wallet_name=f"RANDOM_TRADERS",
+                        key_name=f"LIMIT_{str(i_market).zfill(3)}_AGENT_{str(i_agent).zfill(3)}",
+                        market_name=market_name,
+                        asset_name=asset_name,
+                        time_in_force_opts={"TIME_IN_FORCE_GTT": 1},
+                        buy_volume=1,
+                        sell_volume=1,
+                        buy_intensity=10,
+                        sell_intensity=10,
+                        submit_bias=1,
+                        cancel_bias=0,
+                        duration=120,
+                        price_process=price_process,
+                        spread=0,
+                        mean=-3,
+                        sigma=0.5,
                         tag=f"MARKET_{str(i_market).zfill(3)}_AGENT_{str(i_agent).zfill(3)}",
                     )
                 )
@@ -291,7 +315,7 @@ class FuzzingScenario(Scenario):
                             side=side,
                             initial_asset_mint=1_000,
                             size_factor=0.7,
-                            step_bias=0.01,
+                            step_bias=0.1,
                             tag=f"MARKET_{str(i_market).zfill(3)}_SIDE_{side}_AGENT_{str(i_agent).zfill(3)}",
                         )
                     )
@@ -305,7 +329,7 @@ class FuzzingScenario(Scenario):
                         asset_name=asset_name,
                         initial_asset_mint=1_000,
                         commitment_factor=0.7,
-                        step_bias=0.01,
+                        step_bias=0.1,
                         tag=f"MARKET_{str(i_market).zfill(3)}_AGENT_{str(i_agent).zfill(3)}",
                     )
                 )

--- a/vega_sim/tools/scenario_output.py
+++ b/vega_sim/tools/scenario_output.py
@@ -28,6 +28,7 @@ def history_data_to_row(data: MarketHistoryData) -> List[pd.Series]:
                 "mark_price": market_data.mark_price,
                 "market_id": market_id,
                 "mark_price": market_data.mark_price,
+                "mid_price": market_data.mid_price,
                 "open_interest": market_data.open_interest,
                 "best_bid": market_data.best_bid_price,
                 "best_offer": market_data.best_offer_price,
@@ -37,6 +38,13 @@ def history_data_to_row(data: MarketHistoryData) -> List[pd.Series]:
                 "market_trading_mode": market_data.market_trading_mode,
                 "target_stake": market_data.target_stake,
                 "supplied_stake": market_data.supplied_stake,
+                "price_monitoring_bounds": [
+                    ((bound.min_valid_price, bound.max_valid_price))
+                    for bound in market_data.price_monitoring_bounds
+                ],
+                "indicative_price": market_data.indicative_price,
+                "trigger": market_data.trigger,
+                "extension_trigger": market_data.extension_trigger,
             },
         )
     return results

--- a/vega_sim/tools/scenario_plots.py
+++ b/vega_sim/tools/scenario_plots.py
@@ -614,8 +614,8 @@ def plot_price_monitoring(run_name: Optional[str] = None):
 
         gs = GridSpec(nrows=1, ncols=1, hspace=0.1)
         ax = fig.add_subplot(
-                gs[0, 0],
-            )
+            gs[0, 0],
+        )
         twinax = ax.twinx()
         twinax.set_ylim(0, 1)
 

--- a/vega_sim/tools/scenario_plots.py
+++ b/vega_sim/tools/scenario_plots.py
@@ -1,8 +1,12 @@
-from typing import Optional
+import os
+import ast
 
-import matplotlib.pyplot as plt
 import pandas as pd
+import matplotlib.pyplot as plt
 import vega_sim.proto.vega as vega_protos
+
+from typing import Optional
+from collections import defaultdict
 from matplotlib.axes import Axes
 from matplotlib.figure import Figure
 from matplotlib.markers import MarkerStyle
@@ -356,8 +360,9 @@ def plot_price_comparison(
     external_price_series = fuzzing_df["external_price"].replace(0, np.nan)
     mark_price_series = data_df["mark_price"].replace(0, np.nan)
 
-    ax0.plot(external_price_series)
     ax0.plot(mark_price_series)
+    ax0.set_ylim(ax0.get_ylim())
+    ax0.plot(external_price_series, linewidth=0.8, alpha=0.8)
 
     ep_volatility = external_price_series.var() / external_price_series.size
     mp_volatility = mark_price_series.var() / mark_price_series.size
@@ -567,12 +572,140 @@ def account_plots(run_name: Optional[str] = None, agent_types: Optional[list] = 
     return fig
 
 
+def plot_price_monitoring(run_name: Optional[str] = None):
+    data_df = load_market_data_df(run_name=run_name)
+
+    market_ids = data_df.market_id.unique()
+
+    figs = {}
+    for market_id in market_ids:
+        market_data_df = data_df[data_df["market_id"] == market_id]
+
+        # Extract the tightest valid prices from the price monitoring valid_prices
+        valid_prices = defaultdict(lambda: [])
+        for index in market_data_df.index:
+            all_bounds = ast.literal_eval(
+                market_data_df.loc[index]["price_monitoring_bounds"]
+            )
+            valid_prices["datetime"].append(index)
+            valid_prices["min_valid_price"].append(np.nan)
+            valid_prices["max_valid_price"].append(np.nan)
+            for _, individual_bound in enumerate(all_bounds):
+                valid_prices["min_valid_price"][-1] = (
+                    individual_bound[0]
+                    if valid_prices["min_valid_price"][-1] is np.nan
+                    else max(individual_bound[0], valid_prices["min_valid_price"][-1])
+                )
+                valid_prices["max_valid_price"][-1] = (
+                    individual_bound[1]
+                    if valid_prices["max_valid_price"][-1] is np.nan
+                    else min(individual_bound[1], valid_prices["max_valid_price"][-1])
+                )
+
+        fig = plt.figure(figsize=[10, 7])
+        fig.suptitle(
+            f"Price Monitoring Analysis",
+            fontsize=18,
+            fontweight="bold",
+            color=(0.2, 0.2, 0.2),
+        )
+        fig.tight_layout()
+        plt.rcParams.update({"font.size": 8})
+
+        gs = GridSpec(nrows=1, ncols=1, hspace=0.1)
+        ax = fig.add_subplot(
+                gs[0, 0],
+            )
+        twinax = ax.twinx()
+        twinax.set_ylim(0, 1)
+
+        # Plot period where auctions triggered (but not extended)
+        series = (market_data_df["trigger"] == 3).astype(int) & (
+            market_data_df["extension_trigger"] != 3
+        ).astype(int)
+        twinax.fill_between(
+            series.index,
+            series,
+            step="post",
+            alpha=0.1,
+            color="r",
+            linewidth=0,
+            label="auction",
+        )
+        # Plot periods where auctions extended
+        series = (market_data_df["extension_trigger"] == 3).astype(int)
+        twinax.fill_between(
+            series.index,
+            series,
+            step="post",
+            alpha=0.1,
+            color="orange",
+            linewidth=0,
+            label="extension",
+        )
+
+        ax.plot(
+            valid_prices["datetime"],
+            valid_prices["min_valid_price"],
+            "r-",
+            linewidth=0.5,
+            alpha=0.4,
+            label="valid price bounds",
+        )
+        ax.plot(
+            valid_prices["datetime"],
+            valid_prices["max_valid_price"],
+            "r-",
+            linewidth=0.5,
+            alpha=0.4,
+            label="_nolegend",
+        )
+
+        ax.plot(
+            market_data_df.index,
+            market_data_df["mark_price"].replace(0, np.nan),
+            "b-",
+            alpha=1.0,
+            label="mark price",
+        )
+        ax.plot(
+            market_data_df.index,
+            market_data_df["mid_price"].replace(0, np.nan),
+            "b-",
+            alpha=0.4,
+            label="mid price",
+        )
+        ax.plot(
+            market_data_df.index,
+            market_data_df["indicative_price"].replace(0, np.nan),
+            "g-",
+            alpha=1.0,
+            label="indicative price",
+        )
+
+        ax.legend(loc="upper left")
+        twinax.legend(loc="lower right")
+
+        ax.set_xlabel("datetime")
+        ax.set_ylabel("price")
+
+        figs[market_id] = fig
+
+    return figs
+
+
 if __name__ == "__main__":
+    dir = "test_plots"
+    if not os.path.exists(dir):
+        os.mkdir(dir)
     figs = fuzz_plots()
-    for key, fig in figs.items():
-        fig.savefig(f"fuzz-{key}.jpg")
+    for i, fig in enumerate(figs.values()):
+        fig.savefig(f"{dir}/fuzz-{i}.jpg")
     figs = plot_run_outputs()
-    for key, fig in figs.items():
-        fig.savefig(f"rl-{key}.jpg")
+    for i, fig in enumerate(figs.values()):
+        fig.savefig(f"{dir}/trading-{i}.jpg")
+    figs = plot_price_monitoring()
+    for i, fig in enumerate(figs.values()):
+        fig.savefig(f"{dir}/monitoring-{i}.jpg")
     fig = account_plots()
-    fig.savefig(f"accounts.jpg")
+    fig.savefig(f"{dir}/accounts.jpg")


### PR DESCRIPTION
### Summary

PR improves the fuzz test to better test price-monitoring auctions and loss-socialisation.

### Description

The `price_process` used in the fuzz test has been modified to include the following:
- price-drifts: periods where the price-process drifts
- price-spikes: temporary spikes in the price-process which are corrected

The price-spikes should trigger multiple triggers simultaneously, but only result in a short price-monitoring auction as the market corrects itself. The price-drifts however could trigger multiple triggers at the end of an auction resulting in auction extensions.

To better visualise price-monitoring auctions a `price_monitoring_plot` method has been added:

Long run example:
![monitoring-1](https://user-images.githubusercontent.com/99198652/233694079-82c80af9-0e6e-4068-86ca-486d247349bf.jpg)

Short run example:
![monitoring-0](https://user-images.githubusercontent.com/99198652/233696191-7bef546c-8e24-4778-9d15-2adca28a31e9.jpg)




As a result of the above changes, markets can now exit price-monitoring auctions at a distant price. This causes larger price differences between mark-to-markets which can encourage using funds from the insurance pool and loss-socialisation (degenerate traders can't cover their losses).

![fuzz-1](https://user-images.githubusercontent.com/99198652/233694210-8f7a0b36-1265-4026-b988-648fa1b31433.jpg)


### Testing
Passing all tests locally.

### Breaking Changes
None

### Closes
None
