### PR TITLE
feat: add csv artifacts to market-sim fuzz-test

### DIFF
--- a/scripts/run-docker-fuzz-test.sh
+++ b/scripts/run-docker-fuzz-test.sh
@@ -15,4 +15,5 @@ docker run \
         python -m vega_sim.scenario.fuzzed_markets.run_fuzz_test --steps $1
 
 docker cp fuzz_test:/vega_market_sim/fuzz_plots/. .
+docker cp fuzz_test:/vega_market_sim/run_logs/latest/. .
 docker rm fuzz_test


### PR DESCRIPTION
### Description

To aid investigating any unexpected behaviour in fuzz-test runs it would be useful to have the raw data gathered by the `Snitch` in order to recreate plots or create new plots.

PR updates the fuzz test script to copy all `.csv` files in the latest temporary `run_logs` directory to the local machine. 

[PR](https://github.com/vegaprotocol/jenkins-shared-library/pull/464) in the `jenkins-shared-library` repo makes the necessary changes to the fuzz test pipeline to save the `.csv` files as artifacts.
