### PR TITLE
fix: release threads

### DIFF
--- a/tests/integration/test_devops.py
+++ b/tests/integration/test_devops.py
@@ -20,7 +20,7 @@ def test_devops_scenarios(scenario_to_test: DevOpsScenario):
     """"""
 
     scenario_to_test.step_length_seconds = 10
-    scenario_to_test.simulation_args.n_steps = 300
+    scenario_to_test.simulation_args.n_steps = 60
 
     with VegaServiceNull(
         seconds_per_block=1,

--- a/tests/integration/test_fuzz.py
+++ b/tests/integration/test_fuzz.py
@@ -1,9 +1,11 @@
 import pytest
+import tempfile
+
+import vega_sim.scenario.fuzzed_markets.run_fuzz_test as fuzz
 
 
 @pytest.mark.integration
 def test_fuzz_run():
     # Simply testing that it doesn't error
-    import vega_sim.scenario.fuzzed_markets.run_fuzz_test as fuzz
-
-    fuzz._run(steps=100, output=True)
+    with tempfile.TemporaryDirectory() as temp_dir:
+        fuzz._run(steps=100, output=True, output_dir=temp_dir)

--- a/tests/integration/test_fuzz.py
+++ b/tests/integration/test_fuzz.py
@@ -6,4 +6,4 @@ def test_fuzz_run():
     # Simply testing that it doesn't error
     import vega_sim.scenario.fuzzed_markets.run_fuzz_test as fuzz
 
-    fuzz._run(steps=50, output=True)
+    fuzz._run(steps=100, output=True)

--- a/tests/integration/test_parameter_runner.py
+++ b/tests/integration/test_parameter_runner.py
@@ -16,7 +16,7 @@ def test_parameter_runner(experiment_to_run: experiment.SingleParameterExperimen
         experiment_to_run.runs_per_scenario = (
             1  # Likely only need to test the one run per scenario
         )
-
+        experiment_to_run.scenario.num_steps = 60
         experiment_to_run.scenario.price_process_fn = lambda: random_walk(
             num_steps=experiment_to_run.scenario.num_steps,
             starting_price=1000,

--- a/vega_sim/grpc/client.py
+++ b/vega_sim/grpc/client.py
@@ -30,6 +30,9 @@ class GRPCClient(ABC):
         self.channel = channel
         self._client = self.STUB_CLASS(self.channel)
 
+    def stop(self):
+        self.channel.close()
+
     def __getattr__(self, funcname):
         return getattr(self._client, funcname)
 

--- a/vega_sim/local_data_cache.py
+++ b/vega_sim/local_data_cache.py
@@ -60,8 +60,9 @@ def _queue_forwarder(
                 else:
                     sink.put(output)
     except grpc._channel._MultiThreadedRendezvous as e:
-        if e.details() == "Socket closed":
-            logger.info("Data cache event bus closed")
+        if e.details() in ["Channel closed!", "Socket closed"]:
+            logging.debug(f"Thread finished as {e.details}")
+            logger.info("Data cache event bus closed.")
         else:
             raise e
 

--- a/vega_sim/local_data_cache.py
+++ b/vega_sim/local_data_cache.py
@@ -183,7 +183,7 @@ class LocalDataCache:
         self._kill_thread_sig.set()
         self._observation_thread.join()
         self._forwarding_thread.join()
-        
+
     def time_update_from_feed(
         self,
     ) -> int:

--- a/vega_sim/null_service.py
+++ b/vega_sim/null_service.py
@@ -801,6 +801,9 @@ class VegaServiceNull(VegaService):
         return f"{prefix}localhost:{port}"
 
     def stop(self) -> None:
+        self.core_client.stop()
+        self.core_state_client.stop()
+        self.trading_data_client_v2.stop()
         if self.proc is None:
             logger.info("Stop called but nothing to stop")
         else:

--- a/vega_sim/null_service.py
+++ b/vega_sim/null_service.py
@@ -801,11 +801,12 @@ class VegaServiceNull(VegaService):
         return f"{prefix}localhost:{port}"
 
     def stop(self) -> None:
-        super().stop()
         if self.proc is None:
             logger.info("Stop called but nothing to stop")
         else:
             self.proc.terminate()
+        super().stop()
+
 
     @property
     def wallet_url(self) -> str:

--- a/vega_sim/null_service.py
+++ b/vega_sim/null_service.py
@@ -805,8 +805,9 @@ class VegaServiceNull(VegaService):
             logger.info("Stop called but nothing to stop")
         else:
             self.proc.terminate()
+        if isinstance(self.wallet, SlimWallet):
+            self.wallet.stop()
         super().stop()
-
 
     @property
     def wallet_url(self) -> str:

--- a/vega_sim/scenario/fuzzed_markets/run_fuzz_test.py
+++ b/vega_sim/scenario/fuzzed_markets/run_fuzz_test.py
@@ -18,7 +18,7 @@ from vega_sim.tools.scenario_plots import (
 from matplotlib import pyplot as plt
 
 
-def _run(steps: int = 2880, output: bool = False):
+def _run(steps: int = 2880, output: bool = False, output_dir: str = "fuzz-plots"):
     scenario = FuzzingScenario(
         num_steps=steps,
         step_length_seconds=30,
@@ -42,26 +42,26 @@ def _run(steps: int = 2880, output: bool = False):
         )
 
     if output:
-        if not os.path.exists("fuzz_plots"):
-            os.mkdir("fuzz_plots")
+        if not os.path.exists(output_dir):
+            os.mkdir(output_dir)
 
         fuzz_figs = plot_price_monitoring()
         for key, fig in fuzz_figs.items():
-            fig.savefig(f"fuzz_plots/monitoring-{key}.jpg")
+            fig.savefig(f"{output_dir}/monitoring-{key}.jpg")
             plt.close(fig)
 
         fuzz_figs = fuzz_plots()
         for key, fig in fuzz_figs.items():
-            fig.savefig(f"fuzz_plots/fuzz-{key}.jpg")
+            fig.savefig(f"{output_dir}/fuzz-{key}.jpg")
             plt.close(fig)
 
         trading_figs = plot_run_outputs()
         for key, fig in trading_figs.items():
-            fig.savefig(f"fuzz_plots/trading-{key}.jpg")
+            fig.savefig(f"{output_dir}/trading-{key}.jpg")
             plt.close(fig)
 
         account_fig = account_plots()
-        account_fig.savefig(f"fuzz_plots/accounts-{key}.jpg")
+        account_fig.savefig(f"{output_dir}/accounts-{key}.jpg")
         plt.close(account_fig)
 
 

--- a/vega_sim/wallet/slim_wallet.py
+++ b/vega_sim/wallet/slim_wallet.py
@@ -201,3 +201,6 @@ class SlimWallet(Wallet):
             return self.pub_keys[self.vega_default_wallet_name][name]
         else:
             return self.pub_keys[wallet_name][name]
+
+    def stop(self):
+        self.pool.shutdown(wait=True)


### PR DESCRIPTION
### Description
When running sequential context managers to spin up VegaService instances the number of threads builds up as context managers won't release threads (even `daemon` threads).

PR updates the context manager `__exit__` method to set a flag stopping data cache threads and adds a stop method to the `SlimWallet` to shutdown the thread pool. Changes makes thread count stable in integration tests.

To improve resource cleanup during tests, gRPC channels are now explicitly closed and to reduce test duration the number of steps in devops and parameter tests has been reduced.

### Testing
Passing all tests locally.

### Breaking Changes
None
