### PR TITLE
feat: recurring transfers and reward plots

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-appnope==0.1.3 ; python_version >= "3.9" and python_version < "3.11" and platform_system == "Darwin" or python_version >= "3.9" and python_version < "3.11" and sys_platform == "darwin"
+appnope==0.1.3 ; python_version >= "3.9" and python_version < "3.11" and (platform_system == "Darwin" or sys_platform == "darwin")
 asttokens==2.2.1 ; python_version >= "3.9" and python_version < "3.11"
 attrs==22.2.0 ; python_version >= "3.9" and python_version < "3.11"
 backcall==0.2.0 ; python_version >= "3.9" and python_version < "3.11"
@@ -7,7 +7,7 @@ certifi==2022.12.7 ; python_version >= "3.9" and python_version < "3.11"
 cffi==1.15.1 ; python_version >= "3.9" and python_version < "3.11"
 charset-normalizer==3.1.0 ; python_version >= "3.9" and python_version < "3.11"
 click==8.1.3 ; python_version >= "3.9" and python_version < "3.11"
-colorama==0.4.6 ; python_version >= "3.9" and python_version < "3.11" and sys_platform == "win32" or python_version >= "3.9" and python_version < "3.11" and platform_system == "Windows"
+colorama==0.4.6 ; python_version >= "3.9" and python_version < "3.11" and (sys_platform == "win32" or platform_system == "Windows")
 comm==0.1.3 ; python_version >= "3.9" and python_version < "3.11"
 contourpy==1.0.7 ; python_version >= "3.9" and python_version < "3.11"
 cycler==0.11.0 ; python_version >= "3.9" and python_version < "3.11"

--- a/requirements-learning.txt
+++ b/requirements-learning.txt
@@ -1,5 +1,5 @@
 absl-py==1.4.0 ; python_version >= "3.9" and python_version < "3.11"
-appnope==0.1.3 ; python_version >= "3.9" and python_version < "3.11" and platform_system == "Darwin" or python_version >= "3.9" and python_version < "3.11" and sys_platform == "darwin"
+appnope==0.1.3 ; python_version >= "3.9" and python_version < "3.11" and (platform_system == "Darwin" or sys_platform == "darwin")
 asttokens==2.2.1 ; python_version >= "3.9" and python_version < "3.11"
 attrs==22.2.0 ; python_version >= "3.9" and python_version < "3.11"
 backcall==0.2.0 ; python_version >= "3.9" and python_version < "3.11"
@@ -10,7 +10,7 @@ cffi==1.15.1 ; python_version >= "3.9" and python_version < "3.11"
 charset-normalizer==3.1.0 ; python_version >= "3.9" and python_version < "3.11"
 click==8.1.3 ; python_version >= "3.9" and python_version < "3.11"
 cloudpickle==2.2.1 ; python_version >= "3.9" and python_version < "3.11"
-colorama==0.4.6 ; python_version >= "3.9" and python_version < "3.11" and platform_system == "Windows" or python_version >= "3.9" and python_version < "3.11" and sys_platform == "win32"
+colorama==0.4.6 ; python_version >= "3.9" and python_version < "3.11" and (platform_system == "Windows" or sys_platform == "win32")
 comm==0.1.3 ; python_version >= "3.9" and python_version < "3.11"
 contourpy==1.0.7 ; python_version >= "3.9" and python_version < "3.11"
 cycler==0.11.0 ; python_version >= "3.9" and python_version < "3.11"

--- a/tests/integration/test_trading.py
+++ b/tests/integration/test_trading.py
@@ -354,3 +354,50 @@ def test_recurring_transfer(vega_service_with_market: VegaServiceNull):
     assert party_a_accounts_t2[0].balance == 250
     assert party_b_accounts_t2[0].balance == 1750
 
+
+def test_funding_reward_pool(vega_service_with_market: VegaServiceNull):
+    vega = vega_service_with_market
+    market_id = vega.all_markets()[0].id
+
+    vega.wait_for_total_catchup()
+
+    create_and_faucet_wallet(vega=vega, wallet=PARTY_A, amount=1e3)
+    vega.wait_for_total_catchup()
+
+    asset_id = vega.find_asset_id(symbol=ASSET_NAME, raise_on_missing=True)
+
+    vega.update_network_parameter(
+        proposal_key=MM_WALLET.name,
+        parameter="validators.epoch.length",
+        new_value="10m",
+    )
+    vega.wait_for_total_catchup()
+
+    vega.recurring_transfer(
+        from_key_name=PARTY_A.name,
+        from_account_type=vega_protos.vega.ACCOUNT_TYPE_GENERAL,
+        to_account_type=vega_protos.vega.ACCOUNT_TYPE_REWARD_MAKER_RECEIVED_FEES,
+        asset=asset_id,
+        amount=100,
+        factor=1.0,
+    )
+
+    party_a_accounts_t0 = vega.list_accounts(key_name=PARTY_A.name, asset_id=asset_id)
+
+    assert party_a_accounts_t0[0].balance == 1000
+
+    # Forward one epoch
+    vega.wait_fn(601)
+    vega.wait_for_total_catchup()
+
+    party_a_accounts_t1 = vega.list_accounts(key_name=PARTY_A.name, asset_id=asset_id)
+
+    assert party_a_accounts_t1[0].balance == 900
+
+    # Forward one epoch
+    vega.wait_fn(601)
+    vega.wait_for_total_catchup()
+
+    party_a_accounts_t2 = vega.list_accounts(key_name=PARTY_A.name, asset_id=asset_id)
+
+    assert party_a_accounts_t2[0].balance == 800

--- a/tests/integration/test_trading.py
+++ b/tests/integration/test_trading.py
@@ -358,6 +358,7 @@ def test_recurring_transfer(vega_service_with_market: VegaServiceNull):
     assert party_b_accounts_t2[0].balance == 1750
 
 
+@pytest.mark.integration
 def test_funding_reward_pool(vega_service_with_market: VegaServiceNull):
     vega = vega_service_with_market
     vega.wait_for_total_catchup()

--- a/vega_sim/api/helpers.py
+++ b/vega_sim/api/helpers.py
@@ -7,6 +7,7 @@ from typing import Any, Optional, TypeVar, Union, Callable
 import requests
 from vega_sim.grpc.client import VegaCoreClient, VegaTradingDataClientV2
 from vega_sim.proto.data_node.api.v2.trading_data_pb2 import GetVegaTimeRequest
+from vega_sim.proto.vega.api.v1.core_pb2 import StatisticsRequest
 
 
 T = TypeVar("T")
@@ -147,3 +148,7 @@ def forward(time: str, vega_node_url: str) -> None:
 
     req = requests.post(TIME_FORWARD_URL.format(base_url=vega_node_url), json=payload)
     req.raise_for_status()
+
+
+def statistics(core_data_client: VegaCoreClient):
+    return core_data_client.Statistics(StatisticsRequest()).statistics

--- a/vega_sim/api/trading.py
+++ b/vega_sim/api/trading.py
@@ -659,7 +659,6 @@ def transfer(
     recurring: Optional[vega_protos.commands.v1.commands.RecurringTransfer] = None,
     wallet_name: Optional[str] = None,
 ):
-
     command = vega_protos.commands.v1.commands.Transfer(
         from_account_type=from_account_type,
         to_account_type=to_account_type,

--- a/vega_sim/api/trading.py
+++ b/vega_sim/api/trading.py
@@ -648,7 +648,6 @@ def batch_market_instructions(
 
 def transfer(
     wallet: Wallet,
-    wallet_name: str,
     key_name: str,
     from_account_type: vega_protos.vega.AccountType,
     to: str,
@@ -658,14 +657,17 @@ def transfer(
     reference: Optional[str] = None,
     one_off: Optional[vega_protos.commands.v1.commands.OneOffTransfer] = None,
     recurring: Optional[vega_protos.commands.v1.commands.RecurringTransfer] = None,
+    wallet_name: Optional[str] = None,
 ):
+
     command = vega_protos.commands.v1.commands.Transfer(
         from_account_type=from_account_type,
-        to=to,
         to_account_type=to_account_type,
         asset=asset,
         amount=amount,
     )
+    if to is not None:
+        setattr(command, "to", to)
 
     if reference is not None:
         setattr(command, "reference", reference)

--- a/vega_sim/scenario/common/agents.py
+++ b/vega_sim/scenario/common/agents.py
@@ -2761,6 +2761,9 @@ class Snitch(StateAgent):
                 self.additional_state_fn(self.vega, self.agents)
             )
 
+    def finalise(self):
+        self.assets = self.vega.list_assets()
+
 
 class KeyFunder(Agent):
     NAME_BASE = "key_funder"

--- a/vega_sim/scenario/common/agents.py
+++ b/vega_sim/scenario/common/agents.py
@@ -3004,3 +3004,97 @@ class UncrossAuctionAgent(StateAgentWithWallet):
                 price=curr_price,
                 wait=False,
             )
+
+
+class RewardFunder(StateAgentWithWallet):
+    NAME_BASE = "reward_funder"
+
+    def __init__(
+        self,
+        key_name: str,
+        reward_asset_name: str,
+        transfer_amount: str,
+        initial_mint: float = 1e9,
+        account_type: Optional[str] = None,
+        asset_for_metric_name: Optional[str] = None,
+        metric: Optional[str] = None,
+        market_names: Optional[str] = None,
+        wallet_name: Optional[str] = None,
+        tag: Optional[str] = None,
+    ):
+        super().__init__(wallet_name=wallet_name, key_name=key_name, tag=tag)
+        self.reward_asset_name = reward_asset_name
+        self.transfer_amount = transfer_amount
+        self.initial_mint = initial_mint
+        self.asset_for_metric_name = asset_for_metric_name
+        self.account_type = account_type
+        self.metric = metric
+        self.market_names = market_names
+
+    def initialise(
+        self,
+        vega: Union[VegaServiceNull, VegaServiceNetwork],
+        create_key: bool = True,
+        mint_key: bool = True,
+    ):
+        # Initialise wallet
+        super().initialise(vega=vega, create_key=create_key)
+
+        # Faucet vega tokens
+        self.vega.wait_for_total_catchup()
+        self.vega.mint(
+            wallet_name=self.wallet_name,
+            asset="VOTE",
+            amount=1e4,
+            key_name=self.key_name,
+        )
+        self.vega.wait_fn(1)
+        self.vega.wait_for_total_catchup()
+
+        if vega.find_asset_id(symbol=self.reward_asset_name) is None:
+            # Create asset
+            self.vega.create_asset(
+                wallet_name=self.wallet_name,
+                name=self.reward_asset_name,
+                symbol=self.reward_asset_name,
+                decimals=18,
+                max_faucet_amount=5e10,
+                key_name=self.key_name,
+            )
+        self.vega.wait_fn(1)
+        self.vega.wait_for_total_catchup()
+        reward_asset_id = self.vega.find_asset_id(symbol=self.reward_asset_name)
+
+        if mint_key:
+            # Top up asset
+            self.vega.mint(
+                wallet_name=self.wallet_name,
+                asset=reward_asset_id,
+                amount=self.initial_mint,
+                key_name=self.key_name,
+            )
+        self.vega.wait_fn(1)
+        self.vega.wait_for_total_catchup()
+
+        market_ids = (
+            [self.vega.find_market_id(name) for name in self.market_names]
+            if self.market_names is not None
+            else None
+        )
+        asset_for_metric_id = (
+            self.vega.find_asset_id(self.asset_for_metric_name)
+            if self.asset_for_metric_name is not None
+            else None
+        )
+
+        self.vega.recurring_transfer(
+            from_wallet_name=self.wallet_name,
+            from_key_name=self.key_name,
+            from_account_type=vega_protos.ACCOUNT_TYPE_GENERAL,
+            to_account_type=self.account_type,
+            amount=self.transfer_amount,
+            asset=reward_asset_id,
+            asset_for_metric=asset_for_metric_id,
+            metric=self.metric,
+            markets=market_ids,
+        )

--- a/vega_sim/scenario/configurable_market/agents.py
+++ b/vega_sim/scenario/configurable_market/agents.py
@@ -92,6 +92,7 @@ class ConfigurableMarketManager(StateAgentWithWallet):
                 name=self.asset_name,
                 symbol=self.asset_name,
                 decimals=self.asset_dp,
+                quantum=int(10 ** (self.asset_dp)),
                 max_faucet_amount=10_000_000_000,
                 key_name=self.key_name,
             )

--- a/vega_sim/scenario/configurable_market/agents.py
+++ b/vega_sim/scenario/configurable_market/agents.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union, Dict
+from typing import Optional, Union
 
 from collections import namedtuple
 
@@ -38,7 +38,6 @@ class ConfigurableMarketManager(StateAgentWithWallet):
         tag: Optional[str] = None,
         settlement_price: Optional[float] = None,
         initial_mint: Optional[float] = 1e9,
-        network_parameters: Optional[Dict[str, str]] = None,
     ):
         super().__init__(
             wallet_name=proposal_wallet_name,
@@ -60,7 +59,6 @@ class ConfigurableMarketManager(StateAgentWithWallet):
         self.market_config = (
             market_config if market_config is not None else MarketConfig()
         )
-        self.network_parameters = network_parameters
 
         self.settlement_price = settlement_price
 
@@ -85,19 +83,8 @@ class ConfigurableMarketManager(StateAgentWithWallet):
                 amount=1e4,
                 key_name=self.key_name,
             )
-        self.vega.wait_for_total_catchup()
 
-        # Update network parameters if specified
-        if self.network_parameters is not None:
-            [
-                self.vega.update_network_parameter(
-                    proposal_key=self.key_name,
-                    wallet_name=self.wallet_name,
-                    parameter=key,
-                    new_value=self.network_parameters[key],
-                )
-                for key in self.network_parameters
-            ]
+        self.vega.wait_for_total_catchup()
 
         if self.vega.find_asset_id(symbol=self.asset_name) is None:
             self.vega.create_asset(

--- a/vega_sim/scenario/fuzzed_markets/run_fuzz_test.py
+++ b/vega_sim/scenario/fuzzed_markets/run_fuzz_test.py
@@ -13,6 +13,7 @@ from vega_sim.tools.scenario_plots import (
     plot_run_outputs,
     account_plots,
     plot_price_monitoring,
+    reward_plots,
 )
 
 from matplotlib import pyplot as plt
@@ -60,8 +61,12 @@ def _run(steps: int = 2880, output: bool = False, output_dir: str = "fuzz_plots"
             fig.savefig(f"{output_dir}/trading-{key}.jpg")
             plt.close(fig)
 
+        reward_fig = reward_plots()
+        reward_fig.savefig(f"{output_dir}/rewards.jpg")
+        plt.close(fig)
+
         account_fig = account_plots()
-        account_fig.savefig(f"{output_dir}/accounts-{key}.jpg")
+        account_fig.savefig(f"{output_dir}/accounts.jpg")
         plt.close(account_fig)
 
 

--- a/vega_sim/scenario/fuzzed_markets/scenario.py
+++ b/vega_sim/scenario/fuzzed_markets/scenario.py
@@ -224,6 +224,7 @@ class FuzzingScenario(Scenario):
                     asset_name=asset_name,
                     settlement_price=price_process[-1],
                     tag=f"MARKET_{str(i_market).zfill(3)}",
+                    network_parameters={"validators.epoch.length": "5m"},
                 )
             )
 

--- a/vega_sim/scenario/fuzzed_markets/scenario.py
+++ b/vega_sim/scenario/fuzzed_markets/scenario.py
@@ -393,7 +393,7 @@ class FuzzingScenario(Scenario):
                     RewardFunder(
                         wallet_name="REWARD_FUNDERS",
                         key_name=f"MARKET_{str(i_market).zfill(3)}_AGENT_{str(i_agent).zfill(3)}",
-                        reward_asset_name=str(metric),
+                        reward_asset_name=vega_protos.vega.DispatchMetric.Name(metric),
                         initial_mint=1e9,
                         account_type=account_type,
                         transfer_amount=100,

--- a/vega_sim/scenario/fuzzed_markets/scenario.py
+++ b/vega_sim/scenario/fuzzed_markets/scenario.py
@@ -224,7 +224,6 @@ class FuzzingScenario(Scenario):
                     asset_name=asset_name,
                     settlement_price=price_process[-1],
                     tag=f"MARKET_{str(i_market).zfill(3)}",
-                    network_parameters={"validators.epoch.length": "5m"},
                 )
             )
 

--- a/vega_sim/scenario/scenario.py
+++ b/vega_sim/scenario/scenario.py
@@ -9,7 +9,10 @@ from vega_sim.scenario.common.agents import Snitch, StateAgent, MarketHistoryDat
 from vega_sim.tools.scenario_output import (
     market_data_standard_output,
     agents_standard_output,
+    assets_standard_output,
 )
+
+import vega_sim.proto.vega as vega_protos
 
 
 class Scenario(abc.ABC):
@@ -89,6 +92,7 @@ class Scenario(abc.ABC):
         )
         if output_data:
             agents_standard_output(self.agents)
+            assets_standard_output(self.get_assets())
             market_data_standard_output(self.get_run_data())
             if self.additional_data_output_fns is not None:
                 market_data_standard_output(
@@ -100,6 +104,10 @@ class Scenario(abc.ABC):
 
     def get_snitch(self) -> Optional[Snitch]:
         return self.agents.get("snitch")
+
+    def get_assets(self) -> List[vega_protos.assets.Asset]:
+        snitch = self.get_snitch()
+        return snitch.assets if snitch is not None else []
 
     def get_run_data(self) -> List[MarketHistoryData]:
         snitch = self.get_snitch()

--- a/vega_sim/service.py
+++ b/vega_sim/service.py
@@ -2232,7 +2232,7 @@ class VegaService(ABC):
         recurring_transfer = vega_protos.commands.v1.commands.RecurringTransfer(
             start_epoch=start_epoch
             if start_epoch is not None
-            else int(self.statistics().epoch_seq) + 1
+            else int(self.statistics().epoch_seq)
         )
         # Set the optional RecurringTransfer fields
         if start_epoch is not None:

--- a/vega_sim/service.py
+++ b/vega_sim/service.py
@@ -27,6 +27,7 @@ import vega_sim.proto.vega.data_source_pb2 as data_source_protos
 from vega_sim.api.helpers import (
     get_enum,
     forward,
+    statistics,
     num_to_padded_int,
     wait_for_core_catchup,
     wait_for_datanode_sync,
@@ -2400,3 +2401,7 @@ class VegaService(ABC):
             else None,
             asset_decimals=self.asset_decimals,
         )
+
+    def statistics(self):
+        return statistics(core_data_client=self.core_client)
+

--- a/vega_sim/service.py
+++ b/vega_sim/service.py
@@ -2186,7 +2186,7 @@ class VegaService(ABC):
         Function can be used to setup a recurring transfer of funds between two keys or
         between a key and a network reward pool. If funding a reward pool, a dispatch
         strategy can be specified to fund a specific pool.
-        
+
         Args:
             from_key_name (str):
                 The key name of the source account.

--- a/vega_sim/service.py
+++ b/vega_sim/service.py
@@ -2512,3 +2512,5 @@ class VegaService(ABC):
     def statistics(self):
         return statistics(core_data_client=self.core_client)
 
+    def list_assets(self):
+        return self.data_cache._asset_from_feed.values()

--- a/vega_sim/tools/scenario_plots.py
+++ b/vega_sim/tools/scenario_plots.py
@@ -766,6 +766,8 @@ def reward_plots(run_name: Optional[str] = None):
         plt.xticks(rotation=45)
         axs[-1].legend()
 
+    return fig
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
@@ -810,7 +812,7 @@ if __name__ == "__main__":
     if args.rewards or args.all:
         fig = reward_plots()
         if args.save:
-            figs.savefig(f"{dir}/rewards.jpg")
+            fig.savefig(f"{dir}/rewards.jpg")
 
     if args.show:
         plt.show()

--- a/vega_sim/tools/scenario_plots.py
+++ b/vega_sim/tools/scenario_plots.py
@@ -703,7 +703,7 @@ def reward_plots(run_name: Optional[str] = None):
     agents_df = load_agents_df(run_name=run_name).set_index("agent_key")
 
     joined_df = accounts_df.join(agents_df, on="party_id").join(assets_df, on="asset")
-    
+
     datetime = joined_df.index.unique()
 
     fig = plt.figure(figsize=[11.69, 8.27])
@@ -762,11 +762,10 @@ def reward_plots(run_name: Optional[str] = None):
                 continue
             series = grouped.loc[index]
             series = series.reindex(datetime, fill_value=0)
-            axs[-1].plot(
-                series.index, series.values, label=index
-            )
+            axs[-1].plot(series.index, series.values, label=index)
         plt.xticks(rotation=45)
         axs[-1].legend()
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()

--- a/vega_sim/vegahome/genesis.json
+++ b/vega_sim/vegahome/genesis.json
@@ -173,7 +173,7 @@
       "transfer.minTransferQuantumMultiple": "100",
       "validator.performance.scaling.factor": "0",
       "validators.delegation.minAmount": "1",
-      "validators.epoch.length": "24h",
+      "validators.epoch.length": "5m",
       "validators.vote.required": "0.67"
     },
     "network_limits": {


### PR DESCRIPTION
### Description
Adds a `recurring_transfer` method to service as well a `RewardFunder` agent using the transfers.

`RewardFunder` agents have been added to the fuzzing scenario. Each market has separate reward funders using a separate asset for each of the following dispatch strategies:

- `DISPATCH_METRIC_MAKER_FEES_PAID`
- `DISPATCH_METRIC_MAKER_FEES_RECEIVED`
- `DISPATCH_METRIC_LP_FEES_RECEIVED`
- `DISPATCH_METRIC_MARKET_VALUE`

Plots for viewing which type of agents are receiving which type of reward have been added, e.g:

<img width="1499" alt="Screenshot 2023-05-19 at 14 47 54" src="https://github.com/vegaprotocol/vega-market-sim/assets/99198652/6f5b3a3b-0110-4e95-bbbf-d5e2695ab24b">


### Testing
Passing all tests locally.

To test locally:
1. `python -m vega_sim.scenario.fuzzed_markets.run_fuzz_test -s 100`
2. `python -m vega_sim.tools.scenario_plots --reward --show`

### Breaking Changes
None.

### Closes
Closes #400
