### PR TITLE
fix: risky traders and risky LPs

### DIFF
--- a/vega_sim/scenario/fuzzed_markets/agents.py
+++ b/vega_sim/scenario/fuzzed_markets/agents.py
@@ -273,8 +273,8 @@ class FuzzingAgent(StateAgentWithWallet):
                 fig.write_html("fuzz_plots/coverage.html")
 
 
-class DegenerateTrader(StateAgentWithWallet):
-    NAME_BASE = "degenerate_trader"
+class RiskyMarketOrderTrader(StateAgentWithWallet):
+    NAME_BASE = "risky_market_order_trader"
 
     def __init__(
         self,
@@ -373,8 +373,8 @@ class DegenerateTrader(StateAgentWithWallet):
             )
 
 
-class DegenerateLiquidityProvider(StateAgentWithWallet):
-    NAME_BASE = "degenerate_liquidity_provider"
+class RiskySimpleLiquidityProvider(StateAgentWithWallet):
+    NAME_BASE = "risky_simple_liquidity_provider"
 
     def __init__(
         self,

--- a/vega_sim/scenario/fuzzed_markets/scenario.py
+++ b/vega_sim/scenario/fuzzed_markets/scenario.py
@@ -21,8 +21,8 @@ from vega_sim.scenario.common.agents import (
 )
 from vega_sim.scenario.fuzzed_markets.agents import (
     FuzzingAgent,
-    DegenerateTrader,
-    DegenerateLiquidityProvider,
+    RiskyMarketOrderTrader,
+    RiskySimpleLiquidityProvider,
     FuzzyLiquidityProvider,
 )
 
@@ -53,11 +53,11 @@ def state_extraction_fn(vega: VegaServiceNull, agents: dict):
     for _, agent in agents.items():
         if isinstance(agent, ExponentialShapedMarketMaker):
             external_prices[agent.market_id] = agent.curr_price
-        if isinstance(agent, DegenerateTrader):
+        if isinstance(agent, RiskyMarketOrderTrader):
             trader_close_outs[agent.market_id] = (
                 trader_close_outs.get(agent.market_id, 0) + agent.close_outs
             )
-        if isinstance(agent, DegenerateLiquidityProvider):
+        if isinstance(agent, RiskySimpleLiquidityProvider):
             liquidity_provider_close_outs[agent.market_id] = (
                 liquidity_provider_close_outs.get(agent.market_id, 0) + agent.close_outs
             )
@@ -180,9 +180,9 @@ class FuzzingScenario(Scenario):
         auction_traders = []
         random_traders = []
         fuzz_traders = []
-        degenerate_traders = []
+        risky_traders = []
         fuzz_liquidity_providers = []
-        degenerate_liquidity_providers = []
+        risky_liquidity_providers = []
         reward_funders = []
 
         self.initial_asset_mint = 1e9
@@ -314,9 +314,9 @@ class FuzzingScenario(Scenario):
 
             for side in ["SIDE_BUY", "SIDE_SELL"]:
                 for i_agent in range(10):
-                    degenerate_traders.append(
-                        DegenerateTrader(
-                            wallet_name="DEGENERATE_TRADERS",
+                    risky_traders.append(
+                        RiskyMarketOrderTrader(
+                            wallet_name="risky_traders",
                             key_name=f"MARKET_{str(i_market).zfill(3)}_SIDE_{side}_AGENT_{str(i_agent).zfill(3)}",
                             market_name=market_name,
                             asset_name=asset_name,
@@ -329,30 +329,30 @@ class FuzzingScenario(Scenario):
                     )
 
             for i_agent in range(5):
-                degenerate_liquidity_providers.append(
-                    DegenerateLiquidityProvider(
-                        wallet_name="DEGENERATE_LIQUIDITY_PROVIDERS",
-                        key_name=f"HIGH_DEGEN_MARKET_{str(i_market).zfill(3)}_AGENT_{str(i_agent).zfill(3)}",
+                risky_liquidity_providers.append(
+                    RiskySimpleLiquidityProvider(
+                        wallet_name="risky_liquidity_providers",
+                        key_name=f"HIGH_RISK_LPS_MARKET_{str(i_market).zfill(3)}_AGENT_{str(i_agent).zfill(3)}",
                         market_name=market_name,
                         asset_name=asset_name,
                         initial_asset_mint=1_000,
                         commitment_factor=0.7,
                         step_bias=0.1,
-                        tag=f"HIGH_DEGEN_MARKET_{str(i_market).zfill(3)}_AGENT_{str(i_agent).zfill(3)}",
+                        tag=f"HIGH_RISK_LPS_MARKET_{str(i_market).zfill(3)}_AGENT_{str(i_agent).zfill(3)}",
                     )
                 )
 
             for i_agent in range(45):
-                degenerate_liquidity_providers.append(
-                    DegenerateLiquidityProvider(
-                        wallet_name="DEGENERATE_LIQUIDITY_PROVIDERS",
-                        key_name=f"LOW_DEGEN_MARKET_{str(i_market).zfill(3)}_AGENT_{str(i_agent).zfill(3)}",
+                risky_liquidity_providers.append(
+                    RiskySimpleLiquidityProvider(
+                        wallet_name="risky_liquidity_providers",
+                        key_name=f"LOW_RISK_LPS_MARKET_{str(i_market).zfill(3)}_AGENT_{str(i_agent).zfill(3)}",
                         market_name=market_name,
                         asset_name=asset_name,
                         initial_asset_mint=1_000,
                         commitment_factor=0.5,
                         step_bias=0.1,
-                        tag=f"LOW_DEGEN_MARKET_{str(i_market).zfill(3)}_AGENT_{str(i_agent).zfill(3)}",
+                        tag=f"LOW_RISK_LPS_MARKET_{str(i_market).zfill(3)}_AGENT_{str(i_agent).zfill(3)}",
                     )
                 )
 
@@ -409,8 +409,8 @@ class FuzzingScenario(Scenario):
             + auction_traders
             + random_traders
             + fuzz_traders
-            + degenerate_traders
-            + degenerate_liquidity_providers
+            + risky_traders
+            + risky_liquidity_providers
             + fuzz_liquidity_providers
             + reward_funders
         )

--- a/vega_sim/scenario/fuzzed_markets/scenario.py
+++ b/vega_sim/scenario/fuzzed_markets/scenario.py
@@ -322,7 +322,7 @@ class FuzzingScenario(Scenario):
                             asset_name=asset_name,
                             side=side,
                             initial_asset_mint=1_000,
-                            size_factor=0.7,
+                            size_factor=0.5,
                             step_bias=0.1,
                             tag=f"MARKET_{str(i_market).zfill(3)}_SIDE_{side}_AGENT_{str(i_agent).zfill(3)}",
                         )

--- a/vega_sim/scenario/fuzzed_markets/scenario.py
+++ b/vega_sim/scenario/fuzzed_markets/scenario.py
@@ -335,8 +335,8 @@ class FuzzingScenario(Scenario):
                         key_name=f"HIGH_RISK_LPS_MARKET_{str(i_market).zfill(3)}_AGENT_{str(i_agent).zfill(3)}",
                         market_name=market_name,
                         asset_name=asset_name,
-                        initial_asset_mint=1_000,
-                        commitment_factor=0.7,
+                        initial_asset_mint=20_000,
+                        commitment_factor=0.5,
                         step_bias=0.1,
                         tag=f"HIGH_RISK_LPS_MARKET_{str(i_market).zfill(3)}_AGENT_{str(i_agent).zfill(3)}",
                     )
@@ -349,8 +349,8 @@ class FuzzingScenario(Scenario):
                         key_name=f"LOW_RISK_LPS_MARKET_{str(i_market).zfill(3)}_AGENT_{str(i_agent).zfill(3)}",
                         market_name=market_name,
                         asset_name=asset_name,
-                        initial_asset_mint=1_000,
-                        commitment_factor=0.5,
+                        initial_asset_mint=20_000,
+                        commitment_factor=0.3,
                         step_bias=0.1,
                         tag=f"LOW_RISK_LPS_MARKET_{str(i_market).zfill(3)}_AGENT_{str(i_agent).zfill(3)}",
                     )

--- a/vega_sim/tools/scenario_plots.py
+++ b/vega_sim/tools/scenario_plots.py
@@ -17,8 +17,8 @@ from matplotlib.gridspec import GridSpec, SubplotSpec, GridSpecFromSubplotSpec
 from vega_sim.scenario.fuzzed_markets.agents import (
     FuzzingAgent,
     FuzzyLiquidityProvider,
-    DegenerateTrader,
-    DegenerateLiquidityProvider,
+    RiskyMarketOrderTrader,
+    RiskySimpleLiquidityProvider,
 )
 
 from vega_sim.proto.vega import markets
@@ -383,13 +383,13 @@ def plot_price_comparison(
     ax0.legend(labels=["external price", "mark price"])
 
 
-def plot_degen_close_outs(
+def plot_risky_close_outs(
     fig: Figure,
     accounts_df: pd.DataFrame,
     fuzzing_df: pd.DataFrame,
     ss: Optional[SubplotSpec] = None,
 ):
-    """Plots the number of close outs of degen traders and degen liquidity providers.
+    """Plots the number of close outs of risky traders and risky liquidity providers.
 
     Args:
         fig (matplotlib.figure.Figure):
@@ -442,7 +442,7 @@ def plot_degen_close_outs(
         trader_close_outs_ds.values,
         "r.-",
         markersize=1,
-        label="degen trader close outs",
+        label="risky trader close outs",
     )
 
     lns = ln0 + ln1
@@ -468,7 +468,7 @@ def plot_degen_close_outs(
         liquidity_provider_close_outs_ds.values,
         "r.-",
         markersize=1,
-        label="degen LP close outs",
+        label="risky LP close outs",
     )
 
     lns = ln3 + ln4
@@ -512,7 +512,7 @@ def fuzz_plots(run_name: Optional[str] = None) -> Figure:
             data_df=market_data_df,
             fuzzing_df=market_fuzzing_df,
         )
-        plot_degen_close_outs(
+        plot_risky_close_outs(
             fig,
             ss=gs[2, 0],
             accounts_df=market_accounts_df,
@@ -542,8 +542,8 @@ def account_plots(run_name: Optional[str] = None, agent_types: Optional[list] = 
     agent_types = [
         FuzzingAgent,
         FuzzyLiquidityProvider,
-        DegenerateTrader,
-        DegenerateLiquidityProvider,
+        RiskyMarketOrderTrader,
+        RiskySimpleLiquidityProvider,
     ]
 
     gs = GridSpec(nrows=len(agent_types), ncols=1, hspace=0.5)


### PR DESCRIPTION
### Description
After updates to `genesis` aligning values with mainnet values, risky traders were having there orders rejected for insufficient margin and risky LPs were having there commitments rejected as they were not reaching the `market.liquidityProvision.minLpStakeQuantumMultiple` value.

PR updates the initial mints and risk appetites of the risky traders and liquidity providers.

PR also makes the following name changes:

- `DegenerateTrader` -> `RiskyMarketOrderTrader`
- `DegenerateLiquidityProvider` -> `RiskySimpleLiquidityProvider`

### Testing
Passing all tests locally. To test locally:
```shell
python -m vega_sim.scenario.fuzzed_markets.run_fuzz_test -s 100
```
```shell
python -m vega_sim.tools.scenario_plots --accounts
```
Accounts plots should show balances of risk traders and risky LPs changing.
 
![accounts](https://github.com/vegaprotocol/vega-market-sim/assets/99198652/c124f940-35f2-485d-a96a-17674940856b)

Fuzzing plots should show risky traders and risky LPs getting closed out.
![fuzz-1](https://github.com/vegaprotocol/vega-market-sim/assets/99198652/0faede8e-ce9a-43e7-8aa8-3a7083f79a94)
