### PR TITLE
fix: flaky transfers test

### DIFF
--- a/tests/integration/test_trading.py
+++ b/tests/integration/test_trading.py
@@ -28,6 +28,7 @@ def next_epoch(vega: VegaServiceNull):
             raise Exception(
                 "Epoch not started after forwarding the duration of two epochs."
             )
+    vega.wait_fn(1)
     vega.wait_for_total_catchup()
 
 


### PR DESCRIPTION
### Description
PR adds a `wait_fn` call to the end of the `next_epoch` function in the transfer tests. Ensures any pending transfers occur before balances are checked.

### Testing
Passing all tests locally, following tests run multiple times:

- `tests/integration/test_trading.py::test_recurring_transfer`
- `tests/integration/test_trading.py::test_funding_rewards`
