### PR TITLE
feat: Handle cases with failure to find package

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ For the most part the package is fairly self-contained Python, however there are
 ### Download binaries
 
   - Clone the repository to your local drive
-  - Install the latest version of [Golang](https://go.dev)
   - Install the package into your local environment. 
     - The process for this will vary depending upon your package manager of choice. We provide here a full Poetry `pyproject.toml` and a `requirements.txt` which is derived from it. These are kept in sync through a check on all pull requests. You can [install Poetry here](https://python-poetry.org/docs/#installation) 
     - For Poetry:
@@ -36,6 +35,7 @@ For the most part the package is fairly self-contained Python, however there are
       - Run `python3 -m venv ./.venv`
       - Run `source ./.venv/bin/activate`
       - Run `python3 -m pip install -r requirements.txt`
+  - Download the binaries by running `python -m vega_sim.tools.load_binaries` within your Python environment.
  -  Run `make test` which checks all the python environment + vega imports are set up correctly, doesn't run Vega yet.
  -  Run `make test_integration` which checks that everything is set up correctly. Takes about 5 minutes.
  -  You're good now.

--- a/vega_sim/__init__.py
+++ b/vega_sim/__init__.py
@@ -2,7 +2,10 @@ from importlib import metadata
 from pathlib import Path
 
 VEGA_VERSION = "0.71.4"
-__version__ = metadata.version(__package__)
+try:
+    __version__ = metadata.version(__package__)
+except metadata.PackageNotFoundError:
+    __version__ = ""
 
 vega_home_path = Path(__file__).parent / "vegahome"
 vega_bin_path = Path(__file__).parent / "bin"


### PR DESCRIPTION
### Description
<!---
What is the change?
--->
Error handling for case where Python check fails to find metadata. This is fine to skip as it doesn't fail when building the package for distribution

### Testing
<!---
How has the change been tested? Were new unit/integration tests added and do current ones cover?
--->
Tests pass

### Breaking Changes
<!---
Are any of the changes in this PR breaking/requiring of a change in workflow?
--->
Should be none

### Closes
<!---
Does this close any issues?
--->
