### PR TITLE
feat: market maker margin checks

### DIFF
--- a/test.py
+++ b/test.py
@@ -3,6 +3,7 @@ import logging
 import vega_sim.api.data as data
 import vega_sim.api.data_raw as data_raw
 
+from vega_sim.proto.data_node.api.v2.trading_data_pb2 import GetVegaTimeRequest
 
 from vega_sim.network_service import VegaServiceNetwork
 from vega_sim.scenario.constants import Network
@@ -30,21 +31,19 @@ def calc_maintenance(
 
     # Calculate maintenance margin components for a long position
     slippage_per_unit_long = calculate_spu(
-        riskiest_position=risk_factor_long,
+        riskiest_position=riskiest_long,
         order_book=order_book,
         mark_price=mark_price,
         side="long",
     )
     capped_slippage_long = calc_capped_slippage(
         riskiest_long,
-        max(open_volume, 0),
-        open_orders_long,
         mark_price,
         linear_slippage_factor,
         quadratic_slippage_factor,
     )
     uncapped_slippage_long = calc_uncapped_slippage(
-        max(open_volume, 0), open_orders_long, mark_price, slippage_per_unit_long
+        riskiest_long, mark_price, slippage_per_unit_long
     )
     volume_maintenance_long = calc_volume_maintenance(
         max(open_volume, 0), mark_price, risk_factor_long
@@ -68,21 +67,19 @@ def calc_maintenance(
 
     # Calculate maintenance margin components for a short position
     slippage_per_unit_short = calculate_spu(
-        riskiest_position=risk_factor_short,
+        riskiest_position=riskiest_short,
         order_book=order_book,
         mark_price=mark_price,
         side="short",
     )
     capped_slippage_short = calc_capped_slippage(
         riskiest_short,
-        abs(min(open_volume, 0)),
-        open_orders_short,
         mark_price,
         linear_slippage_factor,
         quadratic_slippage_factor,
     )
     uncapped_slippage_short = calc_uncapped_slippage(
-        abs(min(open_volume, 0)), open_orders_short, mark_price, slippage_per_unit_short
+        riskiest_short, mark_price, slippage_per_unit_short
     )
     volume_maintenance_short = calc_volume_maintenance(
         abs(min(open_volume, 0)), mark_price, risk_factor_short
@@ -109,20 +106,18 @@ def calc_maintenance(
 
 def calc_capped_slippage(
     riskiest_position,
-    open_volume,
-    open_orders,
     mark_price,
     linear_slippage_factor,
     quadratic_slippage_factor,
 ):
     return mark_price * (
         float(linear_slippage_factor) * riskiest_position
-        + float(quadratic_slippage_factor) ** 2 * (open_volume + open_orders)
+        + float(quadratic_slippage_factor) ** 2 * riskiest_position
     )
 
 
-def calc_uncapped_slippage(open_volume, open_orders, mark_price, slippage_per_unit):
-    return mark_price * (open_volume + open_orders) * slippage_per_unit
+def calc_uncapped_slippage(riskiest_position, mark_price, slippage_per_unit):
+    return mark_price * riskiest_position * slippage_per_unit
 
 
 def calc_volume_maintenance(open_volume, mark_price, risk_factor):
@@ -171,21 +166,33 @@ if __name__ == "__main__":
         order_book = vega.market_depth(market_id=MARKET_ID, num_levels=1000)
 
         # Get party data
-        mm_orders = data.list_orders(
-            data_client=vega.trading_data_client_v2,
-            market_id=MARKET_ID,
-            party_id=PARTY_ID,
-            live_only=True,
+        logging.debug(
+            f"timestamp={vega.trading_data_client_v2.GetVegaTime(GetVegaTimeRequest()).timestamp}"
         )
         mm_open_volume = data.positions_by_market(
             data_client=vega.trading_data_client_v2,
             pub_key=PARTY_ID,
             market_id=MARKET_ID,
         ).open_volume
+        logging.debug(
+            f"timestamp={vega.trading_data_client_v2.GetVegaTime(GetVegaTimeRequest()).timestamp}"
+        )
         mm_margin_levels = data.margin_levels(
             data_client=vega.trading_data_client_v2,
             party_id=PARTY_ID,
             market_id=MARKET_ID,
+        )
+        logging.debug(
+            f"timestamp={vega.trading_data_client_v2.GetVegaTime(GetVegaTimeRequest()).timestamp}"
+        )
+        mm_orders = data.list_orders(
+            data_client=vega.trading_data_client_v2,
+            market_id=MARKET_ID,
+            party_id=PARTY_ID,
+            live_only=True,
+        )
+        logging.debug(
+            f"timestamp={vega.trading_data_client_v2.GetVegaTime(GetVegaTimeRequest()).timestamp}"
         )
 
         # Extract the open orders

--- a/test.py
+++ b/test.py
@@ -1,0 +1,212 @@
+import logging
+
+import vega_sim.api.data as data
+import vega_sim.api.data_raw as data_raw
+
+
+from vega_sim.network_service import VegaServiceNetwork
+from vega_sim.scenario.constants import Network
+
+PARTY_ID = "3994b190dd62b51f3c08c85f7d914906d9acbd47ec830be4427746c3719bd5ca"
+MARKET_ID = "84025e68387cf61c2b91228d768dcdd4f10a9ee5cd2824fdea35b259976f59c1"
+
+# Margin calculations split into three components (slippage, volume, orders)
+
+
+def calc_maintenance(
+    open_volume,
+    open_orders_long,
+    open_orders_short,
+    risk_factor_long,
+    risk_factor_short,
+    mark_price,
+    linear_slippage_factor,
+    quadratic_slippage_factor,
+    order_book,
+):
+    # Calculate riskiest long and short position
+    riskiest_long = max([mm_open_volume + open_orders_long, 0])
+    riskiest_short = abs(min([mm_open_volume - open_orders_short, 0]))
+
+    # Calculate maintenance margin components for a long position
+    slippage_per_unit_long = calculate_spu(
+        riskiest_position=risk_factor_long,
+        order_book=order_book,
+        mark_price=mark_price,
+        side="long",
+    )
+    capped_slippage_long = calc_capped_slippage(
+        riskiest_long,
+        max(open_volume, 0),
+        open_orders_long,
+        mark_price,
+        linear_slippage_factor,
+        quadratic_slippage_factor,
+    )
+    uncapped_slippage_long = calc_uncapped_slippage(
+        max(open_volume, 0), open_orders_long, mark_price, slippage_per_unit_long
+    )
+    volume_maintenance_long = calc_volume_maintenance(
+        max(open_volume, 0), mark_price, risk_factor_long
+    )
+    orders_maintenance_long = calculate_orders_maintenance(
+        open_orders_long, mark_price, risk_factor_long
+    )
+    capped_maintenance_long = (
+        capped_slippage_long + volume_maintenance_long + orders_maintenance_long
+    )
+    uncapped_maintenance_long = (
+        uncapped_slippage_long + volume_maintenance_long + orders_maintenance_long
+    )
+    maintenance_long = min([uncapped_maintenance_long, capped_maintenance_long])
+    logging.debug(
+        f"long: capped_maintenance={capped_maintenance_long} ({capped_slippage_long} + {volume_maintenance_long} + {orders_maintenance_long})"
+    )
+    logging.debug(
+        f"long: uncapped_maintenance={uncapped_maintenance_long} ({uncapped_slippage_long} + {volume_maintenance_long} + {orders_maintenance_long})"
+    )
+
+    # Calculate maintenance margin components for a short position
+    slippage_per_unit_short = calculate_spu(
+        riskiest_position=risk_factor_short,
+        order_book=order_book,
+        mark_price=mark_price,
+        side="short",
+    )
+    capped_slippage_short = calc_capped_slippage(
+        riskiest_short,
+        abs(min(open_volume, 0)),
+        open_orders_short,
+        mark_price,
+        linear_slippage_factor,
+        quadratic_slippage_factor,
+    )
+    uncapped_slippage_short = calc_uncapped_slippage(
+        abs(min(open_volume, 0)), open_orders_short, mark_price, slippage_per_unit_short
+    )
+    volume_maintenance_short = calc_volume_maintenance(
+        abs(min(open_volume, 0)), mark_price, risk_factor_short
+    )
+    orders_maintenance_short = calculate_orders_maintenance(
+        open_orders_short, mark_price, risk_factor_short
+    )
+    capped_maintenance_short = (
+        capped_slippage_short + volume_maintenance_short + orders_maintenance_short
+    )
+    uncapped_maintenance_short = (
+        uncapped_slippage_short + volume_maintenance_short + orders_maintenance_short
+    )
+    maintenance_short = min([uncapped_maintenance_short, capped_maintenance_short])
+    logging.debug(
+        f"short: capped_maintenance={capped_maintenance_short} ({capped_slippage_short} + {volume_maintenance_short} + {orders_maintenance_short})"
+    )
+    logging.debug(
+        f"short: uncapped_maintenance={uncapped_maintenance_short} ({uncapped_slippage_short} + {volume_maintenance_short} + {orders_maintenance_short})"
+    )
+
+    return max([maintenance_short, maintenance_long])
+
+
+def calc_capped_slippage(
+    riskiest_position,
+    open_volume,
+    open_orders,
+    mark_price,
+    linear_slippage_factor,
+    quadratic_slippage_factor,
+):
+    return mark_price * (
+        float(linear_slippage_factor) * riskiest_position
+        + float(quadratic_slippage_factor) ** 2 * (open_volume + open_orders)
+    )
+
+
+def calc_uncapped_slippage(open_volume, open_orders, mark_price, slippage_per_unit):
+    return mark_price * (open_volume + open_orders) * slippage_per_unit
+
+
+def calc_volume_maintenance(open_volume, mark_price, risk_factor):
+    return open_volume * mark_price * risk_factor
+
+
+def calculate_orders_maintenance(open_orders, mark_price, risk_factor):
+    return open_orders * mark_price * risk_factor
+
+
+def calculate_spu(riskiest_position, order_book, side, mark_price):
+    if riskiest_position == 0:
+        return 0
+    if side == "short":
+        order_book = order_book.sells
+    else:
+        order_book = reversed(order_book.buys)
+
+    remaining = riskiest_position
+    total_slippage = 0
+    book_volume = 0
+    for price_level in order_book:
+        required = min(remaining, price_level.volume)
+        total_slippage += required * abs(price_level.price - mark_price)
+        remaining += -required
+        book_volume += price_level.volume
+    if remaining > 0:
+        logging.warning(
+            f"Not enough volume on the book ({book_volume}) to close a {side} position of size {riskiest_position}. Slippage capping should be applied."
+        )
+    return total_slippage / riskiest_position
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG)
+
+    with VegaServiceNetwork(
+        network=Network.MAINNET1, run_with_wallet=True, run_with_console=False
+    ) as vega:
+        # Get market data
+        risk_factors = vega.get_risk_factors(market_id=MARKET_ID)
+        market_data = vega.get_latest_market_data(market_id=MARKET_ID)
+        market_info = data_raw.market_info(
+            data_client=vega.trading_data_client_v2, market_id=MARKET_ID
+        )
+        order_book = vega.market_depth(market_id=MARKET_ID, num_levels=1000)
+
+        # Get party data
+        mm_orders = data.list_orders(
+            data_client=vega.trading_data_client_v2,
+            market_id=MARKET_ID,
+            party_id=PARTY_ID,
+            live_only=True,
+        )
+        mm_open_volume = data.positions_by_market(
+            data_client=vega.trading_data_client_v2,
+            pub_key=PARTY_ID,
+            market_id=MARKET_ID,
+        ).open_volume
+        mm_margin_levels = data.margin_levels(
+            data_client=vega.trading_data_client_v2,
+            party_id=PARTY_ID,
+            market_id=MARKET_ID,
+        )
+
+        # Extract the open orders
+        open_orders_long = sum([order.size for order in mm_orders if order.side == 1])
+        open_orders_short = abs(
+            sum([order.size for order in mm_orders if order.side == 2])
+        )
+
+        # Calculate the expected maintenance
+        expected_maintenance = calc_maintenance(
+            open_volume=mm_open_volume,
+            open_orders_long=open_orders_short,
+            open_orders_short=open_orders_short,
+            mark_price=market_data.mark_price,
+            risk_factor_long=risk_factors.long,
+            risk_factor_short=risk_factors.short,
+            linear_slippage_factor=market_info.linear_slippage_factor,
+            quadratic_slippage_factor=market_info.quadratic_slippage_factor,
+            order_book=order_book,
+        )
+
+        logging.info(
+            f"expected maintenance_margin={expected_maintenance} | actual maintenance_margin={mm_margin_levels[0].maintenance_margin}"
+        )

--- a/vega_sim/api/data.py
+++ b/vega_sim/api/data.py
@@ -457,6 +457,15 @@ def positions_by_market(
 ) -> Union[Dict[str, Position], Position]:
     """Output positions of a party."""
 
+    market_price_decimals_map = (
+        market_price_decimals_map if market_price_decimals_map is not None else {}
+    )
+    market_position_decimals_map = (
+        market_position_decimals_map if market_position_decimals_map is not None else {}
+    )
+    market_to_asset_map = market_to_asset_map if market_to_asset_map is not None else {}
+    asset_decimals_map = asset_decimals_map if asset_decimals_map is not None else {}
+
     raw_positions = data_raw.positions_by_market(
         pub_key=pub_key, market_id=market_id, data_client=data_client
     )
@@ -500,8 +509,9 @@ def positions_by_market(
                 asset_id=market_to_asset_map[pos.market_id],
                 data_client=data_client,
             )
-            asset_decimals_map[pos.market_id] = int(asset_info.details.decimals)
-
+            asset_decimals_map[market_to_asset_map[pos.market_id]] = int(
+                asset_info.details.decimals
+            )
         # Convert raw proto into a market-sim Position object
         positions[pos.market_id] = _position_from_proto(
             position=pos,

--- a/vega_sim/scenario/constants.py
+++ b/vega_sim/scenario/constants.py
@@ -9,3 +9,4 @@ class Network(Enum):
     STAGNET3 = "vegawallet-stagnet3"
     FAIRGROUND = "vegawallet-fairground"
     TESTNET2 = "testnet2"
+    MAINNET1 = "mainnet1"


### PR DESCRIPTION
### Summary

Quick script to check margin calculations for market-maker on mainnet. Calculations intentionally don't apply `slippage_per_unit=Inf` when `riskiest_position > volume_on_the_book` to check the rule is being applied correctly.

(i.e. if the logs show an `uncapped_maintenance~=actual_maintenance` then we know there is a problem)

### Examples:

1. `make networks` (ensures you have `mainnet1`)
2. `python -m test`

Check logs to see `maintenance_margin ~= expected_maintenance_margin`. 