### PR TITLE
Allow specifying a parital port_config

### DIFF
--- a/tests/integration/test_port_config.py
+++ b/tests/integration/test_port_config.py
@@ -1,0 +1,27 @@
+import pytest
+from vega_sim.null_service import VegaServiceNull, Ports
+
+
+# Testing that you can specify ports using port_config
+# in the same process ok
+@pytest.mark.integration
+def test_port_config():
+    expected_data_node_rest_port = 2222
+    expected_wallet_port = 1111
+
+    with VegaServiceNull(
+        run_with_console=False,
+        port_config={
+            Ports.DATA_NODE_REST: expected_data_node_rest_port,
+            Ports.WALLET: expected_wallet_port
+        }
+    ) as vega:
+      assert vega.wallet_port == expected_wallet_port
+      assert vega.data_node_rest_port == expected_data_node_rest_port
+      assert isinstance(vega.data_node_grpc_port, int)
+      assert isinstance(vega.data_node_postgres_port, int)
+      assert isinstance(vega.faucet_port, int)
+      assert isinstance(vega.vega_node_port, int)
+      assert isinstance(vega.vega_node_grpc_port, int)
+      assert isinstance(vega.vega_node_rest_port, int)
+      assert isinstance(vega.console_port, int)

--- a/tests/integration/test_port_config.py
+++ b/tests/integration/test_port_config.py
@@ -13,15 +13,15 @@ def test_port_config():
         run_with_console=False,
         port_config={
             Ports.DATA_NODE_REST: expected_data_node_rest_port,
-            Ports.WALLET: expected_wallet_port
-        }
+            Ports.WALLET: expected_wallet_port,
+        },
     ) as vega:
-      assert vega.wallet_port == expected_wallet_port
-      assert vega.data_node_rest_port == expected_data_node_rest_port
-      assert isinstance(vega.data_node_grpc_port, int)
-      assert isinstance(vega.data_node_postgres_port, int)
-      assert isinstance(vega.faucet_port, int)
-      assert isinstance(vega.vega_node_port, int)
-      assert isinstance(vega.vega_node_grpc_port, int)
-      assert isinstance(vega.vega_node_rest_port, int)
-      assert isinstance(vega.console_port, int)
+        assert vega.wallet_port == expected_wallet_port
+        assert vega.data_node_rest_port == expected_data_node_rest_port
+        assert isinstance(vega.data_node_grpc_port, int)
+        assert isinstance(vega.data_node_postgres_port, int)
+        assert isinstance(vega.faucet_port, int)
+        assert isinstance(vega.vega_node_port, int)
+        assert isinstance(vega.vega_node_grpc_port, int)
+        assert isinstance(vega.vega_node_rest_port, int)
+        assert isinstance(vega.console_port, int)

--- a/vega_sim/null_service.py
+++ b/vega_sim/null_service.py
@@ -709,7 +709,7 @@ class VegaServiceNull(VegaService):
                 curr_ports = set(
                     [getattr(self, port) for port in self.PORT_TO_FIELD_MAP.values()]
                 )
-                setattr(self,name, find_free_port(curr_ports))
+                setattr(self, name, find_free_port(curr_ports))
 
     def start(self, block_on_startup: bool = True) -> None:
         if self.check_for_binaries and not self._using_all_custom_paths:

--- a/vega_sim/null_service.py
+++ b/vega_sim/null_service.py
@@ -701,7 +701,7 @@ class VegaServiceNull(VegaService):
         self.console_port = 0
 
         for key, name in self.PORT_TO_FIELD_MAP.items():
-            if key in port_config:
+            if port_config is not None and key in port_config:
                 setattr(self, name, port_config[key])
             else:
                 curr_ports = set(

--- a/vega_sim/null_service.py
+++ b/vega_sim/null_service.py
@@ -689,6 +689,8 @@ class VegaServiceNull(VegaService):
             Ports.CONSOLE: self.console_port,
         }
 
+    # set ports from port_config or alternatively find a free port
+    # to use
     def _assign_ports(self, port_config):
         self.wallet_port = 0
         self.data_node_rest_port = 0

--- a/vega_sim/null_service.py
+++ b/vega_sim/null_service.py
@@ -691,7 +691,7 @@ class VegaServiceNull(VegaService):
 
     # set ports from port_config or alternatively find a free port
     # to use
-    def _assign_ports(self, port_config):
+    def _assign_ports(self, port_config: Optional[Dict[Ports, int]]):
         self.wallet_port = 0
         self.data_node_rest_port = 0
         self.data_node_grpc_port = 0

--- a/vega_sim/null_service.py
+++ b/vega_sim/null_service.py
@@ -635,11 +635,7 @@ class VegaServiceNull(VegaService):
         self.replay_from_path = replay_from_path
         self.check_for_binaries = check_for_binaries
 
-        if port_config is None:
-            self._assign_ports()
-        else:
-            for key, name in self.PORT_TO_FIELD_MAP.items():
-                setattr(self, name, port_config[key])
+        self._assign_ports(port_config)
 
         if start_immediately:
             self.start()
@@ -676,22 +672,6 @@ class VegaServiceNull(VegaService):
                 )
         return self._wallet
 
-    def _assign_ports(self):
-        self.wallet_port = 0
-        self.data_node_rest_port = 0
-        self.data_node_grpc_port = 0
-        self.data_node_postgres_port = 0
-        self.faucet_port = 0
-        self.vega_node_port = 0
-        self.vega_node_grpc_port = 0
-        self.vega_node_rest_port = 0
-        self.console_port = 0
-        for port_opt in self.PORT_TO_FIELD_MAP.values():
-            curr_ports = set(
-                [getattr(self, port) for port in self.PORT_TO_FIELD_MAP.values()]
-            )
-            setattr(self, port_opt, find_free_port(curr_ports))
-
     def _check_started(self) -> None:
         if self.proc is None:
             raise ServiceNotStartedError("NullChain Vega accessed without starting")
@@ -708,6 +688,26 @@ class VegaServiceNull(VegaService):
             Ports.CORE_REST: self.vega_node_rest_port,
             Ports.CONSOLE: self.console_port,
         }
+
+    def _assign_ports(self, port_config):
+        self.wallet_port = 0
+        self.data_node_rest_port = 0
+        self.data_node_grpc_port = 0
+        self.data_node_postgres_port = 0
+        self.faucet_port = 0
+        self.vega_node_port = 0
+        self.vega_node_grpc_port = 0
+        self.vega_node_rest_port = 0
+        self.console_port = 0
+
+        for key, name in self.PORT_TO_FIELD_MAP.items():
+            if key in port_config:
+                setattr(self, name, port_config[key])
+            else:
+                curr_ports = set(
+                    [getattr(self, port) for port in self.PORT_TO_FIELD_MAP.values()]
+                )
+                setattr(self,name, find_free_port(curr_ports))
 
     def start(self, block_on_startup: bool = True) -> None:
         if self.check_for_binaries and not self._using_all_custom_paths:


### PR DESCRIPTION
### Description

Adjusts port config setup so that you can set a single port and not have to provide _all_ the ports

### Testing
Added an integration test `test_port_config.py`

### Breaking Changes
I don't think so, but you might be able to remove some ports if you use port_config and only need to set a few of them

### Closes
N/A
