### PR TITLE
fix: remove startup block forwarding

### DIFF
--- a/vega_sim/null_service.py
+++ b/vega_sim/null_service.py
@@ -793,11 +793,8 @@ class VegaServiceNull(VegaService):
 
             self.process_pids = parent_conn.recv()
 
-            # Create a block before waiting for datanode sync and starting the feeds
-            self.wait_fn(1)
-            self.wait_for_total_catchup()
-            self.wait_for_thread_catchup()
-            self.data_cache
+        # Initialise the data-cache
+        self.data_cache
 
         if self.run_with_console:
             webbrowser.open(f"http://localhost:{port_config[Ports.CONSOLE]}/", new=2)


### PR DESCRIPTION
### Description
PR removes the block forwarding in the `VegaServiceNull` startup which was preventing replays functioning.

```
2023/07/25 12:27:05 invalid state enecountered in price monitoring engine{error 26 0  received a time that's before the last received time}
panic: invalid state enecountered in price monitoring engine{error 26 0  received a time that's before the last received time}

goroutine 394 [running]:
log.Panic({0x1400d2be580?, 0xedbec10a0?, 0x0?})
	/opt/homebrew/Cellar/go/1.19.3/libexec/src/log/log.go:388 +0x64
code.vegaprotocol.io/vega/core/monitor/price.(*Engine).recordTimeChange(0x140011058c0, {0x105865a60?, 0x10807d101?, 0x0?})
	/Users/caed/vega-market-sim/extern/vega/core/monitor/price/pricemonitoring.go:402 +0x134
code.vegaprotocol.io/vega/core/monitor/price.(*Engine).OnTimeUpdate(0x1400c4d5180?, {0x14000f71bd0?, 0x140015ddad0?, 0x0?})
	/Users/caed/vega-market-sim/extern/vega/core/monitor/price/pricemonitoring.go:258 +0x20
code.vegaprotocol.io/vega/core/execution/future.(*Market).OnTick(0x1400c4d5180, {0x1060488e0, 0x140015ddad0}, {0x40?, 0x0?, 0x0?})
	/Users/caed/vega-market-sim/extern/vega/core/execution/future/market.go:660 +0x384
code.vegaprotocol.io/vega/core/execution.(*Engine).OnTick(0x140002ef8c0, {0x1060488e0, 0x140015ddad0}, {0x1?, 0x1060663a0?, 0x0?})
	/Users/caed/vega-market-sim/extern/vega/core/execution/engine.go:959 +0x394
code.vegaprotocol.io/vega/core/vegatime.(*Svc).notify(...)
	/Users/caed/vega-market-sim/extern/vega/core/vegatime/service.go:104
code.vegaprotocol.io/vega/core/vegatime.(*Svc).SetTimeNow(0x14000f7a800, {0x1060488e0, 0x140015ddad0}, {0x107bf4820?, 0x105842100?, 0x0?})
	/Users/caed/vega-market-sim/extern/vega/core/vegatime/service.go:77 +0x278
code.vegaprotocol.io/vega/core/processor.(*App).OnBeginBlock(_, {{0x1400c203400, 0x20, 0x20}, {{0x0, 0x0}, {0x14000fb3120, 0x6}, 0x1, {0x0, ...}, ...}, ...})
	/Users/caed/vega-market-sim/extern/vega/core/processor/abci.go:797 +0x554
code.vegaprotocol.io/vega/core/blockchain/abci.(*App).BeginBlock(_, {{0x1400c203400, 0x20, 0x20}, {{0x0, 0x0}, {0x14000fb3120, 0x6}, 0x1, {0x0, ...}, ...}, ...})
	/Users/caed/vega-market-sim/extern/vega/core/blockchain/abci/abci.go:46 +0x60
code.vegaprotocol.io/vega/cmd/vega/commands/node.(*appW).BeginBlock(_, {{0x1400c203400, 0x20, 0x20}, {{0x0, 0x0}, {0x14000fb3120, 0x6}, 0x1, {0x0, ...}, ...}, ...})
	/Users/caed/vega-market-sim/extern/vega/cmd/vega/commands/node/app_wrapper.go:64 +0x4c
code.vegaprotocol.io/vega/core/blockchain/nullchain.(*NullBlockchain).BeginBlock(0x140014d05a0)
	/Users/caed/vega-market-sim/extern/vega/core/blockchain/nullchain/nullchain.go:336 +0x2ac
code.vegaprotocol.io/vega/core/blockchain/nullchain.(*NullBlockchain).processBlock(0x140014d05a0)
	/Users/caed/vega-market-sim/extern/vega/core/blockchain/nullchain/nullchain.go:195 +0x1b0
code.vegaprotocol.io/vega/core/blockchain/nullchain.(*NullBlockchain).ForwardTime(0x140014d05a0, 0x3b9aca00)
	/Users/caed/vega-market-sim/extern/vega/core/blockchain/nullchain/nullchain.go:272 +0x198
code.vegaprotocol.io/vega/core/blockchain/nullchain.(*NullBlockchain).handleForwardTime.func1()
	/Users/caed/vega-market-sim/extern/vega/core/blockchain/nullchain/server.go:129 +0x2c
created by code.vegaprotocol.io/vega/core/blockchain/nullchain.(*NullBlockchain).handleForwardTime
	/Users/caed/vega-market-sim/extern/vega/core/blockchain/nullchain/server.go:128 +0x1ec

```

### Testing

- Passing all tests locally.

### Additional Testing

- Run any scenario locally:
    ```
    python -m vega_sim.scenario.fuzzed_markets.run_fuzz_test -s 200
    ```
 - Run replay of run locally:
    ```
    python -m vega_sim.replay.replay --dir /var/folders/mq/qntzn9jd0rngp7d0cj8nz9xh0000gn/T/vega-sim-64k2lwl9/vegahome/replay
    ```

### Breaking Changes
The block forward was initially added to help prevent the possibility of the `VOTE` asset not being registered by the cache however this no longer seems to be a problem. Noting in ticket in case it reoccurs.
