### PR TITLE
feat: set of fixes and improvements for vega-market-sim

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,22 @@
+import os
+import logging
+
+# ref: https://pytest-xdist.readthedocs.io/en/latest/how-to.html#creating-one-log-file-for-each-worker
+def pytest_configure(config):
+    path = "test_logs"
+    isExist = os.path.exists(path)
+    if not isExist:
+        os.makedirs(path)
+
+    env_log_level = os.getenv('LOG_LEVEL')
+    log_level = config.getini("log_file_level")
+    if not env_log_level is None:
+        log_level = env_log_level
+
+    worker_id = os.environ.get("PYTEST_XDIST_WORKER")
+    if worker_id is not None:
+        logging.basicConfig(
+            format=config.getini("log_file_format"),
+            filename=f"{path}/tests_{worker_id}.test.log",
+            level=log_level,
+        )

--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,7 @@
 import os
 import logging
 
+
 # ref: https://pytest-xdist.readthedocs.io/en/latest/how-to.html#creating-one-log-file-for-each-worker
 def pytest_configure(config):
     path = "test_logs"
@@ -8,7 +9,7 @@ def pytest_configure(config):
     if not isExist:
         os.makedirs(path)
 
-    env_log_level = os.getenv('LOG_LEVEL')
+    env_log_level = os.getenv("LOG_LEVEL")
     log_level = config.getini("log_file_level")
     if not env_log_level is None:
         log_level = env_log_level

--- a/conftest.py
+++ b/conftest.py
@@ -5,19 +5,13 @@ import logging
 # ref: https://pytest-xdist.readthedocs.io/en/latest/how-to.html#creating-one-log-file-for-each-worker
 def pytest_configure(config):
     path = "test_logs"
-    isExist = os.path.exists(path)
-    if not isExist:
+    if not os.path.exists(path):
         os.makedirs(path)
-
-    env_log_level = os.getenv("LOG_LEVEL")
-    log_level = config.getini("log_file_level")
-    if not env_log_level is None:
-        log_level = env_log_level
 
     worker_id = os.environ.get("PYTEST_XDIST_WORKER")
     if worker_id is not None:
         logging.basicConfig(
             format=config.getini("log_file_format"),
             filename=f"{path}/tests_{worker_id}.test.log",
-            level=log_level,
+            level=os.getenv("LOG_LEVEL", config.getini("log_file_level")),
         )

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,7 +2,7 @@
 markers = 
     integration: mark a test as requiring a full vega sim infrastructure with running backend
 
-log_file_format =%(asctime)s.%(msecs)03d %(threadName)s %(processName)s (%(filename)s:%(funcName)s:%(lineno)s):%(message)s
+log_file_format=%(asctime)s.%(msecs)03d %(threadName)s %(processName)s (%(filename)s:%(funcName)s:%(lineno)s):%(message)s
 log_file_date_format=%Y-%m-%d %H:%M:%S
 
 log_file_level = INFO

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,8 @@
 [pytest]
 markers = 
     integration: mark a test as requiring a full vega sim infrastructure with running backend
+
+log_file_format =%(asctime)s.%(msecs)03d %(threadName)s %(processName)s (%(filename)s:%(funcName)s:%(lineno)s):%(message)s
+log_file_date_format=%Y-%m-%d %H:%M:%S
+
+log_file_level = INFO

--- a/scripts/run-integration-test.sh
+++ b/scripts/run-integration-test.sh
@@ -1,9 +1,21 @@
 #!/usr/bin/env bash
-
 set -e
+
+
+# Default values for environment variables. Those variables may be exported with bash `export <ENV_NAME>=value`
+# Jenkins provides definition of the below variables
+: "${PARALLEL_WORKERS:=0}"
+: "${TEST_FUNCTION:=}"
+: "${LOG_LEVEL:=INFO}"
 
 WORK_DIR="$(realpath "$(dirname "$0")/..")"
 RESULT_DIR="${WORK_DIR}/test_logs/$(date '+%F_%H%M%S')-integration"
 mkdir -p "${RESULT_DIR}"
 
-pytest -s -v -m integration --junitxml ${RESULT_DIR}/integration-test-results.xml --log-cli-level INFO 
+
+set -x
+pytest -s -v -m integration \
+    --junitxml ${RESULT_DIR}/integration-test-results.xml \
+    --log-cli-level "${LOG_LEVEL}" \
+    -n "${PARALLEL_WORKERS}" \
+    -k "${TEST_FUNCTION}" 

--- a/tests/integration/test_reinforcement.py
+++ b/tests/integration/test_reinforcement.py
@@ -2,6 +2,7 @@ import pytest
 
 
 @pytest.mark.integration
+@pytest.mark.skip(reason="We will enable it once job is stable in the Jenkins")
 def test_rl_run():
     # Simply testing that it doesn't error
     import vega_sim.reinforcement.run_rl_agent as rl

--- a/tests/integration/utils/fixtures.py
+++ b/tests/integration/utils/fixtures.py
@@ -1,4 +1,5 @@
 from collections import namedtuple
+import logging
 from typing import Optional
 
 import pytest
@@ -137,7 +138,7 @@ def build_basic_market(
     vega.wait_for_total_catchup()
 
 
-@pytest.fixture
+@pytest.fixture(scope="function")
 def vega_service():
     with VegaServiceNull(
         warn_on_raw_data_access=False,
@@ -147,15 +148,17 @@ def vega_service():
         listen_for_high_volume_stream_updates=False,
     ) as vega:
         yield vega
+    logging.debug("vega_service theardown")
+    
 
 
-@pytest.fixture
+@pytest.fixture(scope="function")
 def vega_service_with_market(vega_service):
     build_basic_market(vega_service, initial_price=0.3)
     return vega_service
 
 
-@pytest.fixture
+@pytest.fixture(scope="function")
 def vega_service_with_high_volume():
     with VegaServiceNull(
         warn_on_raw_data_access=False,
@@ -165,9 +168,10 @@ def vega_service_with_high_volume():
         listen_for_high_volume_stream_updates=True,
     ) as vega:
         yield vega
+    logging.debug("vega_service_with_high_volume theardown")
 
 
-@pytest.fixture
+@pytest.fixture(scope="function")
 def vega_service_with_high_volume_with_market(vega_service_with_high_volume):
     build_basic_market(vega_service_with_high_volume, initial_price=0.3)
     return vega_service_with_high_volume

--- a/tests/integration/utils/fixtures.py
+++ b/tests/integration/utils/fixtures.py
@@ -148,7 +148,7 @@ def vega_service():
         listen_for_high_volume_stream_updates=False,
     ) as vega:
         yield vega
-    logging.debug("vega_service theardown")
+    logging.debug("vega_service teardown")
 
 
 @pytest.fixture(scope="function")
@@ -167,7 +167,7 @@ def vega_service_with_high_volume():
         listen_for_high_volume_stream_updates=True,
     ) as vega:
         yield vega
-    logging.debug("vega_service_with_high_volume theardown")
+    logging.debug("vega_service_with_high_volume teardown")
 
 
 @pytest.fixture(scope="function")

--- a/tests/integration/utils/fixtures.py
+++ b/tests/integration/utils/fixtures.py
@@ -149,7 +149,6 @@ def vega_service():
     ) as vega:
         yield vega
     logging.debug("vega_service theardown")
-    
 
 
 @pytest.fixture(scope="function")

--- a/vega_sim/api/helpers.py
+++ b/vega_sim/api/helpers.py
@@ -67,13 +67,13 @@ def wait_for_datanode_sync(
     *at the time of call* not necessarily the latest data when the function returns.
 
     Wait time is exponential with increasing retries
-    (each attempt waits 0.0005 * 1.01^attempt_num seconds).
+    (each attempt waits 0.05 * 1.03^attempt_num seconds).
     """
     attempts = 1
     core_time = retry(10, 0.5, lambda: core_data_client.GetVegaTime(GetVegaTimeRequest()).timestamp)
     trading_time = retry(10, 0.5, lambda: trading_data_client.GetVegaTime(GetVegaTimeRequest()).timestamp)
     while core_time > trading_time:
-        logging.info(f"Sleeping in wait_for_datanode_sync for {0.05 * 1.03**attempts}")
+        logging.debug(f"Sleeping in wait_for_datanode_sync for {0.05 * 1.03**attempts}")
         time.sleep(0.05 * 1.03**attempts)
         try:
             trading_time = retry(10, 2.0, lambda: trading_data_client.GetVegaTime(GetVegaTimeRequest()).timestamp)
@@ -103,10 +103,10 @@ def wait_for_core_catchup(
     core_time_two = retry(10, 0.5, lambda: core_data_client.GetVegaTime(GetVegaTimeRequest()).timestamp)
 
     while core_time != core_time_two:
-        logging.info(f"Sleeping in wait_for_core_catchup for {0.05 * 1.03**attempts}")
+        logging.debug(f"Sleeping in wait_for_core_catchup for {0.05 * 1.03**attempts}")
 
         core_time = retry(10, 0.5, lambda: core_data_client.GetVegaTime(GetVegaTimeRequest()).timestamp)
-        time.sleep(0.05 * 1.1**attempts)
+        time.sleep(0.05 * 1.03**attempts)
         core_time_two = retry(10, 0.5, lambda: core_data_client.GetVegaTime(GetVegaTimeRequest()).timestamp)
         attempts += 1
         if attempts >= max_retries:

--- a/vega_sim/api/helpers.py
+++ b/vega_sim/api/helpers.py
@@ -70,13 +70,21 @@ def wait_for_datanode_sync(
     (each attempt waits 0.05 * 1.03^attempt_num seconds).
     """
     attempts = 1
-    core_time = retry(10, 0.5, lambda: core_data_client.GetVegaTime(GetVegaTimeRequest()).timestamp)
-    trading_time = retry(10, 0.5, lambda: trading_data_client.GetVegaTime(GetVegaTimeRequest()).timestamp)
+    core_time = retry(
+        10, 0.5, lambda: core_data_client.GetVegaTime(GetVegaTimeRequest()).timestamp
+    )
+    trading_time = retry(
+        10, 0.5, lambda: trading_data_client.GetVegaTime(GetVegaTimeRequest()).timestamp
+    )
     while core_time > trading_time:
         logging.debug(f"Sleeping in wait_for_datanode_sync for {0.05 * 1.03**attempts}")
         time.sleep(0.05 * 1.03**attempts)
         try:
-            trading_time = retry(10, 2.0, lambda: trading_data_client.GetVegaTime(GetVegaTimeRequest()).timestamp)
+            trading_time = retry(
+                10,
+                2.0,
+                lambda: trading_data_client.GetVegaTime(GetVegaTimeRequest()).timestamp,
+            )
         except Exception as e:
             logging.warn(e)
             trading_time = sys.maxsize
@@ -98,16 +106,28 @@ def wait_for_core_catchup(
     in a standard tendermint chain
     """
     attempts = 1
-    core_time = retry(10, 0.5, lambda: core_data_client.GetVegaTime(GetVegaTimeRequest()).timestamp)
+    core_time = retry(
+        10, 0.5, lambda: core_data_client.GetVegaTime(GetVegaTimeRequest()).timestamp
+    )
     time.sleep(0.1)
-    core_time_two = retry(10, 0.5, lambda: core_data_client.GetVegaTime(GetVegaTimeRequest()).timestamp)
+    core_time_two = retry(
+        10, 0.5, lambda: core_data_client.GetVegaTime(GetVegaTimeRequest()).timestamp
+    )
 
     while core_time != core_time_two:
         logging.debug(f"Sleeping in wait_for_core_catchup for {0.05 * 1.03**attempts}")
 
-        core_time = retry(10, 0.5, lambda: core_data_client.GetVegaTime(GetVegaTimeRequest()).timestamp)
+        core_time = retry(
+            10,
+            0.5,
+            lambda: core_data_client.GetVegaTime(GetVegaTimeRequest()).timestamp,
+        )
         time.sleep(0.05 * 1.03**attempts)
-        core_time_two = retry(10, 0.5, lambda: core_data_client.GetVegaTime(GetVegaTimeRequest()).timestamp)
+        core_time_two = retry(
+            10,
+            0.5,
+            lambda: core_data_client.GetVegaTime(GetVegaTimeRequest()).timestamp,
+        )
         attempts += 1
         if attempts >= max_retries:
             raise DataNodeBehindError(
@@ -159,4 +179,6 @@ def forward(time: str, vega_node_url: str) -> None:
 
 
 def statistics(core_data_client: VegaCoreClient):
-    return retry(10, 0.5, lambda: core_data_client.Statistics(StatisticsRequest()).statistics)
+    return retry(
+        10, 0.5, lambda: core_data_client.Statistics(StatisticsRequest()).statistics
+    )

--- a/vega_sim/local_data_cache.py
+++ b/vega_sim/local_data_cache.py
@@ -17,6 +17,7 @@ import vega_sim.api.governance as gov
 import vega_sim.grpc.client as vac
 import vega_sim.proto.vega as vega_protos
 import vega_sim.proto.vega.events.v1.events_pb2 as events_protos
+from vega_sim.tools.retry import retry
 
 logger = logging.getLogger(__name__)
 
@@ -56,7 +57,7 @@ def _queue_forwarder(
             for event in o.events:
                 if (kill_thread_sig is not None) and kill_thread_sig.is_set():
                     return
-                output = handlers[event.type](event)
+                output = retry(5, 1.0, lambda: handlers[event.type](event))
                 if isinstance(output, (list, GeneratorType)):
                     for elem in output:
                         sink.put(elem)

--- a/vega_sim/null_service.py
+++ b/vega_sim/null_service.py
@@ -382,8 +382,6 @@ def manage_vega_processes(
         use_docker_postgres=use_docker_postgres,
     )
 
-    data_node_docker_volume = None
-    data_node_container = None
     if use_docker_postgres:
         data_node_docker_volume = docker_client.volumes.create()
         data_node_container = docker_client.containers.run(
@@ -606,7 +604,8 @@ def manage_vega_processes(
                 except requests.exceptions.HTTPError as e:
                     if e.response.status_code == 404:
                         logger.debug(
-                            f"Container {data_node_container.name} has been already killed"
+                            f"Container {data_node_container.name} has been already"
+                            " killed"
                         )
                         return
                     else:
@@ -626,7 +625,8 @@ def manage_vega_processes(
                     if e.response.status_code == 404:
                         removed = True
                         logger.debug(
-                            f"Data node volume {data_node_docker_volume.name} has been already killed"
+                            f"Data node volume {data_node_docker_volume.name} has been"
+                            " already killed"
                         )
                         break
                     else:
@@ -651,7 +651,8 @@ def manage_vega_processes(
                 attempts += 1
                 if attempts > 60:
                     logger.warning(
-                        f"Gracefully terminating process timed-out. Killing process {name}."
+                        "Gracefully terminating process timed-out. Killing process"
+                        f" {name}."
                     )
                     process.kill()
             logger.debug(f"Process {name} stopped with {process.poll()}")
@@ -666,9 +667,10 @@ def manage_vega_processes(
     # The below lines are workaround to put the signal listeners on top of the stack, so this process can handle it.
     signal.signal(signal.SIGINT, lambda _s, _h: None)
     signal.signal(signal.SIGTERM, lambda _s, _h: None)
-    signal.signal(
-        signal.SIGCHLD, sighandler
-    )  # The process had previously created one or more child processes with the fork() function. One or more of these processes has since died.
+
+    # The process had previously created one or more child processes with the fork() function.
+    # One or more of these processes has since died.
+    signal.signal(signal.SIGCHLD, sighandler)
     signal.sigwait(
         [
             signal.SIGKILL,  # The process was explicitly killed by somebody wielding the kill program.

--- a/vega_sim/null_service.py
+++ b/vega_sim/null_service.py
@@ -381,6 +381,8 @@ def manage_vega_processes(
         use_docker_postgres=use_docker_postgres,
     )
 
+    data_node_docker_volume = None
+    data_node_container = None
     if use_docker_postgres:
         data_node_docker_volume = docker_client.volumes.create()
         data_node_container = docker_client.containers.run(
@@ -569,43 +571,96 @@ def manage_vega_processes(
 
     # Send process pid values for resource monitoring
     child_conn.send({name: process.pid for name, process in processes.items()})
+    
 
-    signal.sigwait([signal.SIGKILL, signal.SIGTERM])
 
-    if use_docker_postgres:
-        data_node_container.stop()
-        removed = False
-        for _ in range(10):
+
+    # According to https://docs.oracle.com/cd/E19455-01/806-5257/gen-75415/index.html
+    # There is no guarantee that signal will be catch by this thread. Usually the 
+    # parent process catches the sisnal and clear the list of pending signals, this 
+    # leave us with memory leak where we have orphaned vega processes and the docker
+    # container. Below is hack to maximize chance by catching the signal. 
+    # There are thread watchers + sigwait. As last resort We catches the `SIGCHLD` 
+    # in case the parent process exited and this is the orphan now.
+    # But to provide 100% guarantee this should be implemented in another way:
+    #   - Signal should be trapped in the main process, and this should be synced 
+    #     the shared memory or this should be incorporated in the VegaServiceNull
+    #     and called directly.
+    # 
+    # Important assumption is that this signal can be caught multiple times as well
+    def sighandler(signal, frame):
+        if signal is None:
+            logging.debug("VegaServiceNull exited normally")
+        else:
+            logging.debug(f"VegaServiceNull exited after trap the {signal} signal")
+
+        logger.debug("Received signal from parent process")
+        if use_docker_postgres:
+            logger.debug(f"Stopping container {data_node_container.name}")
             try:
-                data_node_docker_volume.remove(force=True)
-                removed = True
-                break
-            except docker.errors.APIError:
-                time.sleep(1)
-        if not removed:
-            logging.exception(
-                "Docker volume failed to cleanup, will require manual cleaning"
-            )
-
-    for process in processes.values():
-        process.terminate()
-    for name, process in processes.items():
-        attempts = 0
-        while process.poll() is None:
-            time.sleep(1)
-            attempts += 1
-            if attempts > 60:
-                logging.warning(
-                    f"Gracefully terminating process timed-out. Killing process {name}."
+                data_node_container.kill()
+            except requests.exceptions.HTTPError as e:
+                if e.response.status_code == 404:
+                    logger.debug(f"Container {data_node_container.name} has been already killed")
+                else:
+                    raise e
+            
+            removed = False
+            for _ in range(10):
+                try:
+                    logging.info(f"Removing volume {data_node_docker_volume.name}")
+                    data_node_docker_volume.remove(force=True)
+                    removed = True
+                    break
+                except requests.exceptions.HTTPError as e:
+                    if e.response.status_code == 404:
+                        removed = True
+                        logger.debug(f"Data node volume {data_node_docker_volume.name} has been already killed")
+                        break
+                    else:
+                        time.sleep(1)
+                except docker.errors.APIError:
+                    time.sleep(1)
+            if not removed:
+                logging.exception(
+                    "Docker volume failed to cleanup, will require manual cleaning"
                 )
-                process.kill()
-        if process.poll() == 0:
-            logging.debug(f"Process {name} terminated.")
-        if process.poll() == -9:
-            logging.debug(f"Process {name} killed.")
 
-    if not retain_log_files:
-        shutil.rmtree(tmp_vega_dir)
+
+        logger.debug("Starting termination for processes")
+        for name, process in processes.items():
+            logger.debug(f"Terminating process {name}(pid: {process.pid})")
+            process.terminate()
+
+        for name, process in processes.items():
+            attempts = 0
+            while process.poll() is None:
+                logger.debug(f"Process {name} still not terminated")
+                time.sleep(1)
+                attempts += 1
+                if attempts > 60:
+                    logger.warning(
+                        f"Gracefully terminating process timed-out. Killing process {name}."
+                    )
+                    process.kill()
+            logger.debug(f"Process {name} stopped with {process.poll()}")
+            if process.poll() == 0:
+                logger.debug(f"Process {name} terminated.")
+            if process.poll() == -9:
+                logger.debug(f"Process {name} killed.")
+
+        if not retain_log_files:
+            shutil.rmtree(tmp_vega_dir)
+
+    # The below lines are workaround to put the listeners on top of the stack, so this process can handle it.
+    signal.signal(signal.SIGINT, lambda _s, _h: None)
+    signal.signal(signal.SIGTERM, lambda _s, _h: None)
+    signal.signal(signal.SIGCHLD, sighandler) # The process had previously created one or more child processes with the fork() function. One or more of these processes has since died.
+    signal.sigwait([
+        signal.SIGKILL, # The process was explicitly killed by somebody wielding the kill program.
+        signal.SIGTERM, # The process was explicitly killed by somebody wielding the terminate program.
+    ])
+    sighandler(None, None)
 
 
 class VegaServiceNull(VegaService):
@@ -677,6 +732,8 @@ class VegaServiceNull(VegaService):
         self.launch_graphql = launch_graphql
         self.replay_from_path = replay_from_path
         self.check_for_binaries = check_for_binaries
+
+        self.stopped = False
 
         self._assign_ports(port_config)
 
@@ -853,16 +910,21 @@ class VegaServiceNull(VegaService):
         return f"{prefix}localhost:{port}"
 
     def stop(self) -> None:
+        logging.debug("Calling stop for veganullchain")
+        if self.stopped:
+            return
+        self.stopped = True
         self.core_client.stop()
         self.core_state_client.stop()
         self.trading_data_client_v2.stop()
         if self.proc is None:
             logger.info("Stop called but nothing to stop")
         else:
-            self.proc.terminate()
+            os.kill(self.proc.pid, signal.SIGTERM)
         if isinstance(self.wallet, SlimWallet):
             self.wallet.stop()
         super().stop()
+
 
     @property
     def wallet_url(self) -> str:

--- a/vega_sim/null_service.py
+++ b/vega_sim/null_service.py
@@ -649,10 +649,10 @@ def manage_vega_processes(
             if process.poll() == -9:
                 logger.debug(f"Process {name} killed.")
 
-        if not retain_log_files:
+        if not retain_log_files and os.path.exists(tmp_vega_dir):
             shutil.rmtree(tmp_vega_dir)
 
-    # The below lines are workaround to put the listeners on top of the stack, so this process can handle it.
+    # The below lines are workaround to put the signal listeners on top of the stack, so this process can handle it.
     signal.signal(signal.SIGINT, lambda _s, _h: None)
     signal.signal(signal.SIGTERM, lambda _s, _h: None)
     signal.signal(signal.SIGCHLD, sighandler) # The process had previously created one or more child processes with the fork() function. One or more of these processes has since died.

--- a/vega_sim/service.py
+++ b/vega_sim/service.py
@@ -393,8 +393,8 @@ class VegaService(ABC):
 
         self.wait_fn(1)
         self.wait_for_total_catchup()
-        for i in range(500):
-            time.sleep(0.0005 * 1.01**i)
+        for i in range(100):
+            time.sleep(0.05 * 1.03**i)
             post_acct = self.party_account(
                 wallet_name=wallet_name,
                 asset_id=asset,

--- a/vega_sim/tools/retry.py
+++ b/vega_sim/tools/retry.py
@@ -2,7 +2,8 @@ from typing import TypeVar, Callable
 import time
 import logging
 
-T = TypeVar('T')
+T = TypeVar("T")
+
 
 def retry(attempts: int, delay: float, func: Callable[[], T]) -> T:
     for i in range(attempts):
@@ -14,5 +15,5 @@ def retry(attempts: int, delay: float, func: Callable[[], T]) -> T:
             return result
         except Exception as e:
             time.sleep(delay)
-            if i == attempts-1:
+            if i == attempts - 1:
                 raise Exception(e)

--- a/vega_sim/tools/retry.py
+++ b/vega_sim/tools/retry.py
@@ -1,0 +1,13 @@
+from typing import TypeVar, Callable
+import time
+
+T = TypeVar('T')
+
+def retry(attempts: int, delay: float, func: Callable[[], T]) -> T:
+    for i in range(attempts):
+        try:
+            return func()
+        except Exception as e:
+            time.sleep(delay)
+            if i == attempts-1:
+                raise Exception(e)

--- a/vega_sim/tools/retry.py
+++ b/vega_sim/tools/retry.py
@@ -9,7 +9,7 @@ def retry(attempts: int, delay: float, func: Callable[[], T]) -> T:
     for i in range(attempts):
         try:
             if i > 0:
-                logging.info(f"Retrying attempt {i}")
+                logging.debug(f"Retrying attempt {i}")
             result = func()
 
             return result

--- a/vega_sim/tools/retry.py
+++ b/vega_sim/tools/retry.py
@@ -1,12 +1,17 @@
 from typing import TypeVar, Callable
 import time
+import logging
 
 T = TypeVar('T')
 
 def retry(attempts: int, delay: float, func: Callable[[], T]) -> T:
     for i in range(attempts):
         try:
-            return func()
+            if i > 0:
+                logging.info(f"Retrying attempt {i}")
+            result = func()
+
+            return result
         except Exception as e:
             time.sleep(delay)
             if i == attempts-1:


### PR DESCRIPTION
# Description

### Description

I really need this pipeline to test my nullchain changes in the core.

#### Changes

- Added a generic function to the `tools.retry` function that retries the given code and returns the result or throws an exception when all of the attempts fail.
- Added support for the following parameters: `PARALLEL_WORKERS`, `TEST_FUNCTION`, and `LOG_LEVEL` - They allow driving the integration tests script. Jenkins now has support for it - see the related PR.
- Added support for the parallel run of the scenarios
    - There is a `pytest-dist` library that has been already included in the `poetry.lock`. I have tested those PRs against that run as well
    - There is a limitation when we use parallel run of the scenarios, where pytest does not print logs to the STDOUT anymore. I have added `conftest.py`, and some params in the `pytest.ini`. Those settings enable writing test logs into the file. Now files are saved in the `Jenkins artifacts (you can confirm it here: https://jenkins.ops.vega.xyz/job/common/job/vega-market-sim/2607/artifact/test_logs/ ) - one file per worker.
- Disabled the `test_rl_run` test for the integration run. It takes a very long time to run this single scenario. There is a following issue here(https://github.com/vegaprotocol/vega-market-sim/issues/472) to run it
- The biggest problem was a huge memory leak that caused us to need 64GB of RAM on the server to fit the run. Now we need 16 GB max, with 10 parallel runs the pipeline uses 12 GB. On docker, it could work(I am not sure if it was) because docker manages fork/workers differently. When We disabled docker it started causing huge issues. I have implemented a fix, but this fix is not ideal. I have left a comment block that describes limitations. Here is a follow-up issue to fix it properly: TBD...
- Changed sleep time, there is no reason to sleep `0.0001s` and send up to 1000 requests per second. New sleep is 0.05 and time increases exponentially. Moreover, I have also decreased the number of tries - see details below. 
- Increased time for waiting for the proposal from 0.8 sec to about 2.8 sec. The timeout formula is now `0.05 * 1.1**i`


#### Sleep Changes

- The old sleep formula was: `[0.0005 * 1.01**attempt for attempt in range(625)]`
- The new formula is:  `[0.05 * 1.03**attempt for attempt in range(100)]`

Max wait:
- for new formula: `sum([0.05 * 1.03**i for i in range(100)]) == 30.364386634760475` - 30.4 sec.
- for old formula: `sum([0.0005 * 1.01**i for i in range(625)]) == 25.05895385147325` - 25.1 sec

The difference is that instead of `625` we send max `100` requests.
- When we were sleeping `0.0005` seconds it was sending about **250 requests**, (`sum([0.0005 * 1.01**i for i in range(260)]) - 0.6145492739027707`) sometimes more - this is my observation
- Now it is sending usually 1 request, in some scenarios 3-to 4 requests.

Because we were sending thousands of requests without reason we saw a lot of RPC Connection issues.

### Testing

- https://jenkins.ops.vega.xyz/job/common/job/vega-market-sim/2605/
- https://jenkins.ops.vega.xyz/job/common/job/vega-market-sim/2606/

<img width="311" alt="image" src="https://github.com/vegaprotocol/vega-market-sim/assets/1239637/fad92c0c-8cba-48f5-89e5-6d847587ac5f">


### Breaking Changes

No breaking changes.

### Closes

close vegaprotocol/devops-infra#1531 .

# Related PRs:

- https://github.com/vegaprotocol/jenkins-shared-library/pull/571
- https://github.com/vegaprotocol/vega-market-sim/pull/471