### PR TITLE
chore: update logger warn

### DIFF
--- a/vega_sim/service.py
+++ b/vega_sim/service.py
@@ -80,7 +80,7 @@ def raw_data(fn):
     @wraps(fn)
     def wrapped_fn(self, *args, **kwargs):
         if self.warn_on_raw_data_access:
-            logger.warn(
+            logger.warning(
                 f"Using function with raw data from data-node {fn.__qualname__}. Be"
                 " wary if prices/positions are not converted from int form"
             )


### PR DESCRIPTION
Updating logger.warn due to being depreciated. 
/vega_sim/service.py:83: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
    logger.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
