### PR TITLE
feat: remove liq amendment spec

### DIFF
--- a/vega_sim/api/governance.py
+++ b/vega_sim/api/governance.py
@@ -126,20 +126,14 @@ def propose_market_from_config(
     )
     proposal.terms.new_market.CopyFrom(changes)
 
-    try:
-        return _make_and_wait_for_proposal(
-            wallet=wallet,
-            wallet_name=proposal_wallet_name,
-            key_name=proposal_key_name,
-            proposal=proposal,
-            data_client=data_client,
-            time_forward_fn=time_forward_fn,
-        ).proposal.id
-    except:
-        import pdb
-
-        pdb.set_trace()
-        a = 5
+    return _make_and_wait_for_proposal(
+        wallet=wallet,
+        wallet_name=proposal_wallet_name,
+        key_name=proposal_key_name,
+        proposal=proposal,
+        data_client=data_client,
+        time_forward_fn=time_forward_fn,
+    ).proposal.id
 
 
 def propose_future_market(

--- a/vega_sim/api/governance.py
+++ b/vega_sim/api/governance.py
@@ -126,14 +126,20 @@ def propose_market_from_config(
     )
     proposal.terms.new_market.CopyFrom(changes)
 
-    return _make_and_wait_for_proposal(
-        wallet=wallet,
-        wallet_name=proposal_wallet_name,
-        key_name=proposal_key_name,
-        proposal=proposal,
-        data_client=data_client,
-        time_forward_fn=time_forward_fn,
-    ).proposal.id
+    try:
+        return _make_and_wait_for_proposal(
+            wallet=wallet,
+            wallet_name=proposal_wallet_name,
+            key_name=proposal_key_name,
+            proposal=proposal,
+            data_client=data_client,
+            time_forward_fn=time_forward_fn,
+        ).proposal.id
+    except:
+        import pdb
+
+        pdb.set_trace()
+        a = 5
 
 
 def propose_future_market(

--- a/vega_sim/api/helpers.py
+++ b/vega_sim/api/helpers.py
@@ -109,7 +109,7 @@ def wait_for_core_catchup(
     core_time = retry(
         10, 0.5, lambda: core_data_client.GetVegaTime(GetVegaTimeRequest()).timestamp
     )
-    time.sleep(0.0001)
+    time.sleep(0.1)
     core_time_two = retry(
         10, 0.5, lambda: core_data_client.GetVegaTime(GetVegaTimeRequest()).timestamp
     )

--- a/vega_sim/api/helpers.py
+++ b/vega_sim/api/helpers.py
@@ -78,7 +78,7 @@ def wait_for_datanode_sync(
     )
     while core_time > trading_time:
         logging.debug(f"Sleeping in wait_for_datanode_sync for {0.05 * 1.03**attempts}")
-        time.sleep(0.05 * 1.03**attempts)
+        time.sleep(0.01 * 1.03**attempts)
         try:
             trading_time = retry(
                 10,
@@ -109,7 +109,7 @@ def wait_for_core_catchup(
     core_time = retry(
         10, 0.5, lambda: core_data_client.GetVegaTime(GetVegaTimeRequest()).timestamp
     )
-    time.sleep(0.1)
+    time.sleep(0.0001)
     core_time_two = retry(
         10, 0.5, lambda: core_data_client.GetVegaTime(GetVegaTimeRequest()).timestamp
     )
@@ -122,7 +122,7 @@ def wait_for_core_catchup(
             0.5,
             lambda: core_data_client.GetVegaTime(GetVegaTimeRequest()).timestamp,
         )
-        time.sleep(0.05 * 1.03**attempts)
+        time.sleep(0.0001 * 1.03**attempts)
         core_time_two = retry(
             10,
             0.5,
@@ -145,7 +145,7 @@ def wait_for_acceptance(
         try:
             proposal = submission_load_func(submission_ref)
         except:
-            time.sleep(0.05 * 1.1**i)
+            time.sleep(0.001 * 1.1**i)
             continue
 
         if proposal:

--- a/vega_sim/scenario/common/agents.py
+++ b/vega_sim/scenario/common/agents.py
@@ -1081,6 +1081,7 @@ class ShapedMarketMaker(StateAgentWithWallet):
         safety_factor: Optional[float] = 1.2,
         max_order_size: float = 10000,
         order_validity_length: Optional[float] = None,
+        auto_top_up: bool = False,
     ):
         super().__init__(wallet_name=wallet_name, key_name=key_name, tag=tag)
         self.price_process_generator = price_process_generator
@@ -1109,6 +1110,9 @@ class ShapedMarketMaker(StateAgentWithWallet):
         self.bid_depth = None
         self.ask_depth = None
 
+        self.auto_top_up = auto_top_up
+        self.mint_key = False
+
         self.order_validity_length = order_validity_length
 
     def initialise(
@@ -1122,6 +1126,7 @@ class ShapedMarketMaker(StateAgentWithWallet):
 
         # Get asset id
         self.asset_id = self.vega.find_asset_id(symbol=self.asset_name)
+
         self.mint_key = mint_key
         if mint_key:
             # Top up asset
@@ -1248,7 +1253,7 @@ class ShapedMarketMaker(StateAgentWithWallet):
                 else None
             )
         ) is not None:
-            if self.mint_key:
+            if self.auto_top_up and self.mint_key:
                 # Top up asset
                 account = self.vega.party_account(
                     key_name=self.key_name,
@@ -3054,6 +3059,7 @@ class UncrossAuctionAgent(StateAgentWithWallet):
         initial_asset_mint: float = 1000000,
         tag: str = "",
         wallet_name: str = None,
+        auto_top_up: bool = False,
     ):
         super().__init__(wallet_name=wallet_name, key_name=key_name, tag=tag)
         self.side = side
@@ -3062,6 +3068,8 @@ class UncrossAuctionAgent(StateAgentWithWallet):
         self.asset_name = asset_name
         self.price_process = price_process
         self.uncrossing_size = uncrossing_size
+        self.auto_top_up = auto_top_up
+        self.mint_key = False
 
     def initialise(
         self,
@@ -3071,7 +3079,6 @@ class UncrossAuctionAgent(StateAgentWithWallet):
     ):
         # Initialise wallet
         super().initialise(vega=vega, create_key=create_key)
-        self.mint_key = mint_key
 
         # Get market id
         self.market_id = self.vega.find_market_id(name=self.market_name)
@@ -3079,6 +3086,8 @@ class UncrossAuctionAgent(StateAgentWithWallet):
         self.vega.wait_for_total_catchup()
         # Get asset id
         self.asset_id = self.vega.find_asset_id(symbol=self.asset_name)
+        self.mint_key = mint_key
+
         if self.mint_key:
             # Top up asset
             self.vega.mint(
@@ -3097,7 +3106,7 @@ class UncrossAuctionAgent(StateAgentWithWallet):
             markets_protos.Market.TradingMode.TRADING_MODE_OPENING_AUCTION,
             markets_protos.Market.TradingMode.TRADING_MODE_MONITORING_AUCTION,
         ]:
-            if self.mint_key:
+            if self.auto_top_up and self.mint_key:
                 account = self.vega.party_account(
                     key_name=self.key_name,
                     wallet_name=self.wallet_name,

--- a/vega_sim/scenario/common/agents.py
+++ b/vega_sim/scenario/common/agents.py
@@ -1,16 +1,15 @@
 from __future__ import annotations
 
-import uuid
-import psutil
-import platform
-
 import datetime
 import logging
+import platform
+import uuid
 from dataclasses import dataclass
 from math import exp
 from queue import Queue
 
 import numpy as np
+import psutil
 
 try:
     import talib
@@ -26,6 +25,7 @@ from numpy.typing import ArrayLike
 
 import vega_sim.api.faucet as faucet
 from vega_sim.api.data import AccountData, MarketDepth, Order, Trade
+from vega_sim.api.helpers import get_enum
 from vega_sim.api.trading import OrderRejectedError
 from vega_sim.environment import VegaState
 from vega_sim.environment.agent import Agent, StateAgent, StateAgentWithWallet
@@ -35,8 +35,6 @@ from vega_sim.proto.vega import markets as markets_protos
 from vega_sim.proto.vega import vega as vega_protos
 from vega_sim.scenario.common.utils.ideal_mm_models import GLFT_approx, a_s_mm_model
 from vega_sim.service import PeggedOrder
-
-from vega_sim.api.helpers import get_enum
 
 WalletConfig = namedtuple("WalletConfig", ["name", "passphrase"])
 
@@ -948,9 +946,7 @@ class MarketManager(StateAgentWithWallet):
         self.initial_mint = (
             initial_mint
             if initial_mint is not None
-            else (2 * commitment_amount)
-            if commitment_amount is not None
-            else 100
+            else (2 * commitment_amount) if commitment_amount is not None else 100
         )
 
         self.market_name = market_name
@@ -1126,6 +1122,7 @@ class ShapedMarketMaker(StateAgentWithWallet):
 
         # Get asset id
         self.asset_id = self.vega.find_asset_id(symbol=self.asset_name)
+        self.mint_key = mint_key
         if mint_key:
             # Top up asset
             self.vega.mint(
@@ -1251,6 +1248,25 @@ class ShapedMarketMaker(StateAgentWithWallet):
                 else None
             )
         ) is not None:
+            if self.mint_key:
+                # Top up asset
+                account = self.vega.party_account(
+                    key_name=self.key_name,
+                    wallet_name=self.wallet_name,
+                    asset_id=self.asset_id,
+                    market_id=self.market_id,
+                )
+
+                if account.general < 3 * liq.amount:
+                    # Top up asset
+                    self.vega.mint(
+                        wallet_name=self.wallet_name,
+                        asset=self.asset_id,
+                        amount=self.initial_asset_mint,
+                        key_name=self.key_name,
+                    )
+                    self.vega.wait_for_total_catchup()
+
             self.vega.submit_liquidity(
                 wallet_name=self.wallet_name,
                 market_id=self.market_id,
@@ -1258,7 +1274,6 @@ class ShapedMarketMaker(StateAgentWithWallet):
                 fee=liq.fee,
                 buy_specs=liq.buy_specs,
                 sell_specs=liq.sell_specs,
-                is_amendment=True,
                 key_name=self.key_name,
             )
 
@@ -3056,17 +3071,19 @@ class UncrossAuctionAgent(StateAgentWithWallet):
     ):
         # Initialise wallet
         super().initialise(vega=vega, create_key=create_key)
+        self.mint_key = mint_key
+
         # Get market id
         self.market_id = self.vega.find_market_id(name=self.market_name)
 
         self.vega.wait_for_total_catchup()
         # Get asset id
-        asset_id = self.vega.find_asset_id(symbol=self.asset_name)
-        if mint_key:
+        self.asset_id = self.vega.find_asset_id(symbol=self.asset_name)
+        if self.mint_key:
             # Top up asset
             self.vega.mint(
                 wallet_name=self.wallet_name,
-                asset=asset_id,
+                asset=self.asset_id,
                 amount=self.initial_asset_mint,
                 key_name=self.key_name,
             )
@@ -3080,6 +3097,22 @@ class UncrossAuctionAgent(StateAgentWithWallet):
             markets_protos.Market.TradingMode.TRADING_MODE_OPENING_AUCTION,
             markets_protos.Market.TradingMode.TRADING_MODE_MONITORING_AUCTION,
         ]:
+            if self.mint_key:
+                account = self.vega.party_account(
+                    key_name=self.key_name,
+                    wallet_name=self.wallet_name,
+                    asset_id=self.asset_id,
+                    market_id=self.market_id,
+                )
+
+                if account.general < self.uncrossing_size * curr_price:
+                    # Top up asset
+                    self.vega.mint(
+                        wallet_name=self.wallet_name,
+                        asset=self.asset_id,
+                        amount=self.initial_asset_mint,
+                        key_name=self.key_name,
+                    )
             self.vega.submit_order(
                 trading_key=self.key_name,
                 trading_wallet=self.wallet_name,

--- a/vega_sim/scenario/common/agents.py
+++ b/vega_sim/scenario/common/agents.py
@@ -946,7 +946,9 @@ class MarketManager(StateAgentWithWallet):
         self.initial_mint = (
             initial_mint
             if initial_mint is not None
-            else (2 * commitment_amount) if commitment_amount is not None else 100
+            else (2 * commitment_amount)
+            if commitment_amount is not None
+            else 100
         )
 
         self.market_name = market_name


### PR DESCRIPTION
### Description
<!---
What is the change?
--->

Removing specification that liquidity is an amendment to make standard liquidity provider work in cases where the market rolls over. Also adding auto top-up for some bots

### Testing
<!---
How has the change been tested? Were new unit/integration tests added and do current ones cover?
--->

Ran and works locally

### Breaking Changes
<!---
Are any of the changes in this PR breaking/requiring of a change in workflow?
--->

None

### Closes
<!---
Does this close any issues?
--->
