### PR TITLE
feat: improve risky market order trader logic

### DIFF
--- a/vega_sim/scenario/fuzzed_markets/agents.py
+++ b/vega_sim/scenario/fuzzed_markets/agents.py
@@ -344,15 +344,16 @@ class RiskyMarketOrderTrader(StateAgentWithWallet):
             self.commitment_amount = 0
             return
 
+        midprice = vega_state.market_state[self.market_id].midprice
+
         if (
             vega_state.market_state[self.market_id].trading_mode
             != markets_protos.Market.TradingMode.TRADING_MODE_CONTINUOUS
+            or midprice == 0
         ):
             return
         if self.random_state.rand() > self.step_bias:
             return
-
-        midprice = vega_state.market_state[self.market_id].midprice
 
         if account.general > 0:
             add_to_margin = max(


### PR DESCRIPTION
### Description
Crash in overnight fuzz test when `RiskyMarketOrderTrader` attempted to place order with enormous size.

Trader likely computing large size as mid was reported as `0` (no bid or ask).
```
size = add_to_margin / (midprice * risk_factor + 1e-20)
```

PR improves trader logic to skip step if the mid is `0`.
