### PR TITLE
feat: do not call api for invalid asset ids

### DIFF
--- a/vega_sim/api/data.py
+++ b/vega_sim/api/data.py
@@ -1381,8 +1381,10 @@ def list_accounts(
         )
     return output_accounts
 
+
 def is_valid_vega_id(resource_id: str) -> bool:
     return len(resource_id) == 64 and all(c in string.hexdigits for c in resource_id)
+
 
 def party_account(
     pub_key: str,

--- a/vega_sim/api/data.py
+++ b/vega_sim/api/data.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import string
 from collections import namedtuple
 from dataclasses import dataclass
 from typing import (
@@ -1364,6 +1365,9 @@ def list_accounts(
     asset_decimals_map = {} if asset_decimals_map is None else asset_decimals_map
     output_accounts = []
     for account in accounts:
+        if not is_valid_vega_id(account.asset):
+            continue
+
         if account.asset not in asset_decimals_map:
             asset_decimals_map[account.asset] = get_asset_decimals(
                 asset_id=account.asset,
@@ -1377,6 +1381,8 @@ def list_accounts(
         )
     return output_accounts
 
+def is_valid_vega_id(resource_id: str) -> bool:
+    return len(resource_id) == 64 and all(c in string.hexdigits for c in resource_id)
 
 def party_account(
     pub_key: str,


### PR DESCRIPTION
### Description

For the fairground, We still have invalid asset IDs for example this asset:

```
    {
      "id": "XYZgamma",
      "details": {
        "name": "XYZ (γ gamma)",
        "symbol": "XYZgamma",
        "decimals": "5",
        "quantum": "1",
        "builtinAsset": {
          "maxFaucetAmountMint": "100000000000"
        }
      },
      "status": "STATUS_ENABLED"
    },
```

When We try to get this asset We are getting error from the API.

```
grpc._channel._InactiveRpcError: <_InactiveRpcError of RPC that terminated with:
	status = StatusCode.INVALID_ARGUMENT
	details = "InvalidArgument error"
	debug_error_string = "UNKNOWN:Error received from peer ipv4:164.92.198.87:3007 {created_time:"2023-10-26T20:31:07.333307057+00:00", grpc_status:3, grpc_message:"InvalidArgument error"}"
>
```

This is left over because the fairground has been running for a very long time, and We didn't have a chance to remove those assets.
