### PR TITLE
feat: Adding healthcheck before startup for faucet

### DIFF
--- a/vega_sim/null_service.py
+++ b/vega_sim/null_service.py
@@ -955,6 +955,10 @@ class VegaServiceNull(VegaService):
                     requests.get(
                         f"http://localhost:{self.vega_node_rest_port}/blockchain/height"
                     ).raise_for_status()
+                    requests.get(
+                        f"http://localhost:{self.faucet_port}/api/v1/health"
+                    ).raise_for_status()
+
                     if self._use_full_vega_wallet:
                         requests.get(
                             f"http://localhost:{self.wallet_port}/api/v2/health"


### PR DESCRIPTION
### Description
<!---
What is the change?
--->

Adding health check to faucet endpoint before startup to ensure the faucet service is ready. Investigating whether this is the cause of sporadic Jenkins errors and a useful thing to check in any case.

### Testing
<!---
How has the change been tested? Were new unit/integration tests added and do current ones cover?
--->

Integration tests pass

### Breaking Changes
<!---
Are any of the changes in this PR breaking/requiring of a change in workflow?
--->

None

### Closes
<!---
Does this close any issues?
--->
