### PR TITLE
feat: integrate network parameters into local data cache

### DIFF
--- a/tests/vega_sim/api/test_data.py
+++ b/tests/vega_sim/api/test_data.py
@@ -38,6 +38,7 @@ from vega_sim.api.data import (
     PeggedOrder,
     IcebergOpts,
     StopOrder,
+    NetworkParameter,
     get_asset_decimals,
     find_asset_id,
     get_trades,
@@ -57,6 +58,7 @@ from vega_sim.api.data import (
     list_team_referees,
     list_team_referee_history,
     list_stop_orders,
+    list_network_parameters,
 )
 from vega_sim.grpc.client import (
     VegaTradingDataClientV2,
@@ -1397,4 +1399,56 @@ def test_list_stop_orders(trading_data_v2_servicer_and_port):
                 price=1000.0,
             ),
         )
+    ]
+
+
+def test_list_network_parameters(trading_data_v2_servicer_and_port):
+    def ListNetworkParameters(self, request, context):
+        return data_node_protos_v2.trading_data.ListNetworkParametersResponse(
+            network_parameters=data_node_protos_v2.trading_data.NetworkParameterConnection(
+                page_info=data_node_protos_v2.trading_data.PageInfo(
+                    has_next_page=False,
+                    has_previous_page=False,
+                    start_cursor="",
+                    end_cursor="",
+                ),
+                edges=[
+                    data_node_protos_v2.trading_data.NetworkParameterEdge(
+                        cursor="cursor",
+                        node=vega_protos.vega.NetworkParameter(
+                            key="key_a",
+                            value="value_a",
+                        ),
+                    ),
+                    data_node_protos_v2.trading_data.NetworkParameterEdge(
+                        cursor="cursor",
+                        node=vega_protos.vega.NetworkParameter(
+                            key="key_b",
+                            value="value_b",
+                        ),
+                    ),
+                    data_node_protos_v2.trading_data.NetworkParameterEdge(
+                        cursor="cursor",
+                        node=vega_protos.vega.NetworkParameter(
+                            key="key_c",
+                            value="value_c",
+                        ),
+                    )
+                ],
+            )
+        )
+
+    server, port, mock_servicer = trading_data_v2_servicer_and_port
+    mock_servicer.ListNetworkParameters = ListNetworkParameters
+
+    add_TradingDataServiceServicer_v2_to_server(mock_servicer(), server)
+
+    data_client = VegaTradingDataClientV2(f"localhost:{port}")
+    network_parameters = list_network_parameters(
+        data_client=data_client,
+    )
+    assert network_parameters == [
+        NetworkParameter("key_a", "value_a"),
+        NetworkParameter("key_b", "value_b"),
+        NetworkParameter("key_c", "value_c"),
     ]

--- a/tests/vega_sim/api/test_data.py
+++ b/tests/vega_sim/api/test_data.py
@@ -1433,7 +1433,7 @@ def test_list_network_parameters(trading_data_v2_servicer_and_port):
                             key="key_c",
                             value="value_c",
                         ),
-                    )
+                    ),
                 ],
             )
         )

--- a/vega_sim/api/data.py
+++ b/vega_sim/api/data.py
@@ -369,6 +369,16 @@ class MakerFeesGenerated:
     maker_fees_paid: List[PartyAmount]
 
 
+@dataclass(frozen=True)
+class NetworkParameter:
+    key: str
+    value: str
+
+
+def _network_parameter_from_proto(network_parameter: vega_protos.vega.NetworkParameter):
+    return NetworkParameter(key=network_parameter.key, value=network_parameter.value)
+
+
 def _maker_fees_generated_from_proto(
     maker_fees_generated: vega_protos.events.v1.events.MakerFeesGenerated,
     decimal_spec: DecimalSpec,
@@ -2667,4 +2677,13 @@ def list_stop_orders(
             ),
         )
         for stop_order_event in response
+    ]
+
+
+def list_network_parameters(
+    data_client: vac.trading_data_grpc_v2,
+) -> List[NetworkParameter]:
+    response = data_raw.list_network_parameters(data_client=data_client)
+    return [
+        _network_parameter_from_proto(network_parameter=proto) for proto in response
     ]

--- a/vega_sim/api/data.py
+++ b/vega_sim/api/data.py
@@ -2293,6 +2293,16 @@ def market_data_subscription_handler(
     )
 
 
+def network_parameter_handler(
+    stream: Iterable[vega_protos.api.v1.core.ObserveEventBusResponse],
+) -> Transfer:
+    return _stream_handler(
+        stream_item=stream,
+        extraction_fn=lambda evt: evt.network_parameter,
+        conversion_fn=_network_parameter_from_proto,
+    )
+
+
 def get_latest_market_data(
     market_id: str,
     data_client: vac.VegaTradingDataClientV2,

--- a/vega_sim/api/data_raw.py
+++ b/vega_sim/api/data_raw.py
@@ -459,6 +459,19 @@ def get_network_parameter(
 
 
 @_retry(3)
+def list_network_parameters(
+    data_client: vac.VegaTradingDataClientV2,
+) -> List[vega_protos.vega.NetworkParameter]:
+    base_request = data_node_protos_v2.trading_data.ListNetworkParametersRequest()
+
+    return unroll_v2_pagination(
+        base_request=base_request,
+        request_func=lambda x: data_client.ListNetworkParameters(x).network_parameters,
+        extraction_func=lambda res: [i.node for i in res.edges],
+    )
+
+
+@_retry(3)
 def list_transfers(
     data_client: vac.VegaTradingDataClientV2,
     party_id: Optional[str] = None,

--- a/vega_sim/local_data_cache.py
+++ b/vega_sim/local_data_cache.py
@@ -182,8 +182,8 @@ class LocalDataCache:
             ),
             (
                 (events_protos.BUS_EVENT_TYPE_NETWORK_PARAMETER,),
-                lambda evt: data.network_parameter_handler(
-                    evt,
+                lambda evt: data._network_parameter_from_proto(
+                    evt.network_parameter,
                 ),
             ),
         ]

--- a/vega_sim/local_data_cache.py
+++ b/vega_sim/local_data_cache.py
@@ -108,6 +108,7 @@ class LocalDataCache:
         self.market_data_lock = threading.RLock()
         self.trades_lock = threading.RLock()
         self.ledger_entries_lock = threading.RLock()
+        self.network_parameter_lock = threading.RLock()
         self._time_update_from_feed = 0
         self._live_order_state_from_feed = {}
         self._dead_order_state_from_feed = {}
@@ -120,6 +121,7 @@ class LocalDataCache:
         self._account_keys_for_market = {}
         self._trades_from_feed: List[data.Trade] = []
         self._ledger_entries_from_feed: List[data.LedgerEntry] = []
+        self._network_parameter_from_feed: Dict[str, data.NetworkParameter] = {}
 
         self._observation_thread = None
         self._aggregated_observation_feed: Queue[Any] = Queue()
@@ -176,6 +178,12 @@ class LocalDataCache:
                     self._market_price_decimals,
                     self._market_to_asset,
                     self._asset_decimals,
+                ),
+            ),
+            (
+                (events_protos.BUS_EVENT_TYPE_NETWORK_PARAMETER,),
+                lambda evt: data.network_parameter_handler(
+                    evt,
                 ),
             ),
         ]
@@ -278,6 +286,14 @@ class LocalDataCache:
                         transfers_dict.setdefault(party_id, {})[transfer_id] = transfer
         return transfers_dict
 
+    def network_parameter_from_feed(
+        self,
+        key: str,
+    ) -> data.NetworkParameter:
+        if key not in self._network_parameter_from_feed:
+            self.initialise_network_parameters()
+        return self._network_parameter_from_feed[key]
+
     def start_live_feeds(
         self,
         market_ids: Optional[Union[str, List[str]]] = None,
@@ -306,6 +322,7 @@ class LocalDataCache:
         self.initialise_market_data(
             market_ids,
         )
+        self.initialise_network_parameters()
 
         self._observation_thread = threading.Thread(
             target=self._monitor_stream, daemon=True
@@ -440,6 +457,15 @@ class LocalDataCache:
             for t in base_transfers:
                 self._transfer_state_from_feed.setdefault(t.party_to, {})[t.id] = t
 
+    def initialise_network_parameters(self):
+        base_network_parameters = data.list_network_parameters(
+            data_client=self._trading_data_client
+        )
+
+        with self.transfers_lock:
+            for p in base_network_parameters:
+                self._network_parameter_from_feed[p.key] = p
+
     def _monitor_stream(self) -> None:
         while not self._kill_thread_sig.is_set():
             try:
@@ -522,6 +548,10 @@ class LocalDataCache:
                         self._account_keys_for_market.setdefault(
                             update.market_id, set()
                         ).add(update.account_id)
+
+                elif isinstance(update, data.NetworkParameter):
+                    with self.network_parameter_lock:
+                        self._network_parameter_from_feed[update.key] = update
 
                 elif update is None:
                     logger.debug("Failed to process event into update.")

--- a/vega_sim/service.py
+++ b/vega_sim/service.py
@@ -1949,6 +1949,9 @@ class VegaService(ABC):
             live_only=live_only, blockchain_time=blockchain_time
         )
 
+    def network_parameter_from_feed(self, key: str) -> data.NetworkParameter:
+        return self.data_cache.network_parameter_from_feed(key=key)
+
     @raw_data
     def liquidity_provisions(
         self,

--- a/vega_sim/tools/retry.py
+++ b/vega_sim/tools/retry.py
@@ -16,4 +16,4 @@ def retry(attempts: int, delay: float, func: Callable[[], T]) -> T:
         except Exception as e:
             time.sleep(delay)
             if i == attempts - 1:
-                raise Exception(e)
+                raise e


### PR DESCRIPTION
### Description
As part of converting all governance methods to accept `datetime` objects instead of timestamps, methods will be updated to default the `datetime` objects to their soonest possible value the relevant network parameters allow (this change is needed to allow `console-test` to set network parameters to preferable values without breaking governance methods). To speed up this process, methods will get network parameter values from a feed rather than through API requests.

To support this, PR integrates network parameter update events into the local data cache.

### Testing
Passing all tests locally

### Breaking Changes
None
