### PR TITLE
fIx: fuzzing agents except custom VegaProtoValueError

### DIFF
--- a/vega_sim/builders/__init__.py
+++ b/vega_sim/builders/__init__.py
@@ -1,3 +1,3 @@
-from . import commands, governance, vega
+from . import exceptions, commands, governance, vega
 
-__all__ = ["commands", "governance", "vega"]
+__all__ = ["exceptions", "commands", "governance", "vega"]

--- a/vega_sim/builders/commands/commands.py
+++ b/vega_sim/builders/commands/commands.py
@@ -14,11 +14,13 @@ import vega_sim.proto.vega as vega_protos
 
 from typing import Optional, Dict
 from vega_sim.api.helpers import num_to_padded_int
+from vega_sim.builders.exceptions import raise_custom_build_errors
 
 
 logger = logging.getLogger(__name__)
 
 
+@raise_custom_build_errors
 def proposal_submission(
     reference: str,
     terms: vega_protos.governance.ProposalTerms,
@@ -29,6 +31,7 @@ def proposal_submission(
     )
 
 
+@raise_custom_build_errors
 def transfer(
     asset_decimals: Dict[str, int],
     from_account_type: vega_protos.vega.AccountType.Value,
@@ -55,12 +58,14 @@ def transfer(
     return transfer
 
 
+@raise_custom_build_errors
 def one_off_transfer(deliver_on: datetime.datetime):
     return vega_protos.commands.v1.commands.OneOffTransfer(
         deliver_on=int(deliver_on.timestamp() * 1e9)
     )
 
 
+@raise_custom_build_errors
 def recurring_transfer(
     start_epoch: int,
     factor: float,
@@ -78,6 +83,7 @@ def recurring_transfer(
     return recurring_transfer
 
 
+@raise_custom_build_errors
 def stop_orders_submission(
     rises_above: Optional[vega_protos.commands.v1.commands.StopOrderSetup] = None,
     falls_below: Optional[vega_protos.commands.v1.commands.StopOrderSetup] = None,
@@ -87,6 +93,7 @@ def stop_orders_submission(
     )
 
 
+@raise_custom_build_errors
 def stop_order_setup(
     market_price_decimals: Dict[str, int],
     market_id: str,
@@ -117,6 +124,7 @@ def stop_order_setup(
     return stop_order_setup
 
 
+@raise_custom_build_errors
 def iceberg_opts(
     market_pos_decimals: Dict[str, int],
     market_id: str,
@@ -131,6 +139,7 @@ def iceberg_opts(
     )
 
 
+@raise_custom_build_errors
 def pegged_order(
     market_price_decimals: Dict[str, int],
     market_id: str,

--- a/vega_sim/builders/exceptions.py
+++ b/vega_sim/builders/exceptions.py
@@ -1,16 +1,18 @@
 import logging
 
 from typing import Callable
+from functools import wraps
 
 
 def raise_custom_build_errors(func: Callable):
-    def inner(*args, **kwargs):
+    @wraps(func)
+    def wrapped_fn(*args, **kwargs):
         try:
             return func(*args, **kwargs)
         except ValueError as ve:
             raise VegaProtoValueError(ve)
 
-    return inner
+    return wrapped_fn
 
 
 class VegaProtoValueError(ValueError):

--- a/vega_sim/builders/exceptions.py
+++ b/vega_sim/builders/exceptions.py
@@ -1,0 +1,17 @@
+import logging
+
+from typing import Callable
+
+
+def raise_custom_build_errors(func: Callable):
+    def inner(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except ValueError as ve:
+            raise VegaProtoValueError(ve)
+    return inner
+
+
+class VegaProtoValueError(ValueError):
+    def __init__(self, ve):
+        logging.debug(ve)

--- a/vega_sim/builders/exceptions.py
+++ b/vega_sim/builders/exceptions.py
@@ -9,6 +9,7 @@ def raise_custom_build_errors(func: Callable):
             return func(*args, **kwargs)
         except ValueError as ve:
             raise VegaProtoValueError(ve)
+
     return inner
 
 

--- a/vega_sim/builders/governance.py
+++ b/vega_sim/builders/governance.py
@@ -13,11 +13,13 @@ import vega_sim.proto.vega as vega_protos
 
 from typing import Optional, Dict
 from vega_sim.api.helpers import num_to_padded_int
+from vega_sim.builders.exceptions import raise_custom_build_errors
 
 
 logger = logging.getLogger(__name__)
 
 
+@raise_custom_build_errors
 def proposal_terms(
     closing_timestamp: datetime.datetime,
     enactment_timestamp: datetime.datetime,
@@ -83,6 +85,7 @@ def proposal_terms(
     return proposal_terms
 
 
+@raise_custom_build_errors
 def proposal_rational(
     description: str, title: str
 ) -> vega_protos.governance.ProposalRationale:
@@ -91,12 +94,14 @@ def proposal_rational(
     )
 
 
+@raise_custom_build_errors
 def new_transfer(
     changes: vega_protos.governance.NewTransferConfiguration,
 ) -> vega_protos.governance.NewTransfer:
     return vega_protos.governance.NewTransfer(changes=changes)
 
 
+@raise_custom_build_errors
 def new_transfer_configuration(
     asset_decimals: Dict[str, int],
     source_type: vega_protos.vega.AccountType,
@@ -131,6 +136,7 @@ def new_transfer_configuration(
     return new_transfer_configuration
 
 
+@raise_custom_build_errors
 def one_off_transfer(
     deliver_on: Optional[datetime.datetime] = None,
 ) -> vega_protos.governance.OneOffTransfer:
@@ -140,6 +146,7 @@ def one_off_transfer(
     return one_off_transfer
 
 
+@raise_custom_build_errors
 def recurring_transfer(
     start_epoch: int,
     end_epoch: Optional[int] = None,
@@ -155,6 +162,7 @@ def recurring_transfer(
     return recurring_transfer
 
 
+@raise_custom_build_errors
 def vote_submission(proposal_id: str, value: vega_protos.governance.Vote.Value.Value):
     return vega_protos.commands.v1.commands.VoteSubmission(
         proposal_id=proposal_id, value=value

--- a/vega_sim/builders/vega.py
+++ b/vega_sim/builders/vega.py
@@ -12,11 +12,13 @@ import logging
 import vega_sim.proto.vega as vega_protos
 
 from typing import Optional, List
+from vega_sim.builders.exceptions import raise_custom_build_errors
 
 
 logger = logging.getLogger(__name__)
 
 
+@raise_custom_build_errors
 def dispatch_strategy(
     asset_for_metric: str,
     metric: vega_protos.vega.DispatchMetric.Value,
@@ -65,5 +67,6 @@ def dispatch_strategy(
     return dispatch_strategy
 
 
+@raise_custom_build_errors
 def rank(start_rank: int, share_ratio: int) -> vega_protos.vega.Rank:
     return vega_protos.vega.Rank(start_rank=start_rank, share_ratio=share_ratio)

--- a/vega_sim/service.py
+++ b/vega_sim/service.py
@@ -81,10 +81,6 @@ class VegaFaucetError(Exception):
     pass
 
 
-class VegaCommandError(Exception):
-    pass
-
-
 class MarketStateUpdateType(Enum):
     Unspecified = (
         vega_protos.governance.MarketStateUpdateType.MARKET_STATE_UPDATE_TYPE_UNSPECIFIED


### PR DESCRIPTION
### Description
All builder methods now catch `ValueError` exceptions and instead raise a custom `VegaProtoValueError`.

This allows fuzzing agents to except this custom exception when fuzzed values cause a value error.