### PR TITLE
feat: auction exit visualisation

### DIFF
--- a/examples/visualisations/README.md
+++ b/examples/visualisations/README.md
@@ -4,3 +4,4 @@ This folder contains scripts used to generate market conditions required for cer
 
 - [Party closed out with out loss socialisation](./closed_out.py)
 - [Party closed out with loss socialisation](./loss_socialisation.py)
+- [Fees paid on auction exit](./auction_exit.py)

--- a/examples/visualisations/auction_exit.py
+++ b/examples/visualisations/auction_exit.py
@@ -56,7 +56,7 @@ class AuctionExitVisualisation(Visualisation):
             maker_fee=0.001,
             liquidity_fee=0.001,
             infrastructure_fee=0.001,
-            price_monitoring=True,
+            simple_price_monitoring=False,
         )
 
         # Create wallets and keys for traders

--- a/examples/visualisations/auction_exit.py
+++ b/examples/visualisations/auction_exit.py
@@ -1,0 +1,210 @@
+"""auction_exit.py
+
+Script launches an example of a market which is suspended and put into a monitoring
+auction after price monitoring bounds are breached. When the auction ends the trades
+causing the auction to exist should incur no maker fee.
+
+When running the example with the --console flag, the user will be able to inspect the
+positions of the following parties:
+
+    • TRADER_A: buyer when exiting auction
+    • TRADER_B: seller when exiting auction
+
+Usage:
+
+    python -m examples.visualisations.auction_exit --console --pause
+
+Flags:
+
+    --console   will launch the console
+    --debug     will log debug messages 
+    --pause     will pause the script after each price movement
+
+"""
+
+import argparse
+import logging
+
+from collections import namedtuple
+from numpy.random import RandomState
+
+from vega_sim.null_service import VegaServiceNull
+from examples.visualisations.utils import continuous_market, move_market, Visualisation
+
+from vega_sim.scenario.common.utils.price_process import random_walk
+
+
+PartyConfig = namedtuple("WalletConfig", ["wallet_name", "key_name"])
+
+WALLET_NAME = "vega"
+
+TRADER_A = PartyConfig(wallet_name=WALLET_NAME, key_name="Trader A Party")
+TRADER_B = PartyConfig(wallet_name=WALLET_NAME, key_name="Trader B Party")
+
+
+class AuctionExitVisualisation(Visualisation):
+    START_PRICE = 500
+
+    SEED = None
+
+    def run(self, pause: bool = False, test: bool = False):
+        # Setup a market and move it into a continuous trading state
+        market_id, asset_id, best_ask_id, best_bid_id = continuous_market(
+            vega=self.vega,
+            price=self.START_PRICE,
+            spread=10,
+            maker_fee=0.001,
+            liquidity_fee=0.001,
+            infrastructure_fee=0.001,
+            price_monitoring=True,
+        )
+
+        # Create wallets and keys for traders
+        self.vega.create_key(
+            name=TRADER_A.key_name,
+            wallet_name=TRADER_A.wallet_name,
+        )
+        self.vega.create_key(
+            name=TRADER_B.key_name,
+            wallet_name=TRADER_B.wallet_name,
+        )
+        self.vega.wait_for_total_catchup()
+        self.vega.wait_fn(60)
+
+        # Mint settlement assets for traders
+        self.vega.mint(
+            wallet_name=TRADER_A.wallet_name,
+            key_name=TRADER_A.key_name,
+            asset=asset_id,
+            amount=1e9,
+        )
+        self.vega.mint(
+            wallet_name=TRADER_B.wallet_name,
+            key_name=TRADER_B.key_name,
+            asset=asset_id,
+            amount=1e9,
+        )
+        self.vega.wait_fn(1)
+        self.vega.wait_for_total_catchup()
+
+        logging.info(
+            "Trader A Party: public_key ="
+            f" {self.vega.wallet.public_key(name=TRADER_A.key_name, wallet_name=TRADER_A.wallet_name)}"
+        )
+        logging.info(
+            "Trader B Party: public_key ="
+            f" {self.vega.wallet.public_key(name=TRADER_B.key_name, wallet_name=TRADER_B.wallet_name)}"
+        )
+
+        if pause:
+            input(f"Paused after trader initialisation. View a public key.")
+
+        # Go through market movements
+        price_process = random_walk(
+            num_steps=60,
+            random_state=RandomState(self.SEED),
+            sigma=1,
+            starting_price=self.START_PRICE,
+        )
+        for price in price_process:
+            move_market(
+                vega=self.vega,
+                market_id=market_id,
+                best_ask_id=best_ask_id,
+                best_bid_id=best_bid_id,
+                price=price,
+                spread=10,
+                volume=1,
+            )
+            self.vega.wait_fn(30)
+            self.vega.wait_for_total_catchup()
+        if pause:
+            input("Pausing before triggering auction.")
+
+        # Trigger a price monitoring auction
+        move_market(
+            vega=self.vega,
+            market_id=market_id,
+            best_ask_id=best_ask_id,
+            best_bid_id=best_bid_id,
+            price=10000,
+            spread=10,
+            volume=1,
+        )
+        self.vega.wait_fn(1)
+        if pause:
+            input("Pausing after triggering auction.")
+
+        # Return market to sensible price
+        move_market(
+            vega=self.vega,
+            market_id=market_id,
+            best_ask_id=best_ask_id,
+            best_bid_id=best_bid_id,
+            price=price_process[-1],
+            spread=10,
+            volume=1,
+        )
+        self.vega.wait_fn(1)
+        self.vega.submit_order(
+            trading_wallet=TRADER_A.wallet_name,
+            trading_key=TRADER_A.key_name,
+            market_id=market_id,
+            time_in_force="TIME_IN_FORCE_GTC",
+            order_type="TYPE_LIMIT",
+            side="SIDE_BUY",
+            volume=100,
+            price=price_process[-1],
+        )
+        self.vega.wait_fn(1)
+        self.vega.submit_order(
+            trading_wallet=TRADER_B.wallet_name,
+            trading_key=TRADER_B.key_name,
+            market_id=market_id,
+            time_in_force="TIME_IN_FORCE_GTC",
+            order_type="TYPE_LIMIT",
+            side="SIDE_SELL",
+            volume=100,
+            price=price_process[-1],
+        )
+        self.vega.wait_fn(1)
+        self.vega.wait_fn(60)
+        self.vega.wait_for_total_catchup()
+
+        if pause:
+            input("Pausing after exiting auction.")
+
+        if test:
+            trader_a_trades = self.vega.get_trades(
+                market_id=market_id,
+                wallet_name=TRADER_A.wallet_name,
+                key_name=TRADER_A.key_name,
+            )
+            trader_b_trades = self.vega.get_trades(
+                market_id=market_id,
+                wallet_name=TRADER_B.wallet_name,
+                key_name=TRADER_B.key_name,
+            )
+            for trade in trader_a_trades:
+                assert trade.buyer_fee.maker_fee == 0
+                assert trade.seller_fee.maker_fee == 0
+            for trade in trader_b_trades:
+                assert trade.buyer_fee.maker_fee == 0
+                assert trade.seller_fee.maker_fee == 0
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--console", action="store_true")
+    parser.add_argument("--debug", action="store_true")
+    parser.add_argument("--pause", action="store_true")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.DEBUG if args.debug else logging.INFO)
+
+    with VegaServiceNull(
+        run_with_console=args.console,
+        warn_on_raw_data_access=False,
+    ) as vega:
+        vis = AuctionExitVisualisation(vega=vega)
+        vis.run(pause=args.pause, test=True)

--- a/examples/visualisations/utils.py
+++ b/examples/visualisations/utils.py
@@ -88,7 +88,9 @@ def continuous_market(
     asset_id = propose_asset(vega=vega)
     mint_settlement_asset(vega=vega, asset_id=asset_id)
 
-    market_id = propose_market(vega=vega, asset_id=asset_id, price_monitoring=price_monitoring)
+    market_id = propose_market(
+        vega=vega, asset_id=asset_id, price_monitoring=price_monitoring
+    )
     provide_liquidity(vega=vega, market_id=market_id, fee=liquidity_fee)
 
     best_ask_id, best_bid_id = exit_auction(
@@ -230,7 +232,7 @@ def propose_market(
     )
     if not price_monitoring:
         market_config.set("price_monitoring_parameters.triggers", [])
-        
+
     vega.create_market_from_config(
         proposal_wallet_name=AUX_PARTY_A.wallet_name,
         proposal_key_name=AUX_PARTY_A.key_name,

--- a/tests/integration/test_trading.py
+++ b/tests/integration/test_trading.py
@@ -1,5 +1,4 @@
 import pytest
-import logging
 from collections import namedtuple
 import vega_sim.proto.vega as vega_protos
 from examples.visualisations.utils import continuous_market, move_market
@@ -505,15 +504,6 @@ def test_liquidation_price_witin_estimate_position_bounds_AC002(
     vega.wait_fn(1)
     vega.wait_for_total_catchup()
 
-    logging.info(
-        "Trader A Party: public_key ="
-        f" {vega.wallet.public_key(name=trader_a.key_name, wallet_name=trader_a.wallet_name)}"
-    )
-    logging.info(
-        "Trader B Party: public_key ="
-        f" {vega.wallet.public_key(name=trader_b.key_name, wallet_name=trader_b.wallet_name)}"
-    )
-
     # 0012-NP-LIPE-002: An estimate is obtained for a short position with no open orders, mark price keeps going up in small increments and the actual liquidation takes place within the estimated range.
     vega.submit_order(
         trading_wallet=trader_a.wallet_name,
@@ -543,8 +533,6 @@ def test_liquidation_price_witin_estimate_position_bounds_AC002(
         market_id=market_id,
     )
     collateral = account_TRADER_B.margin + account_TRADER_B.general
-    print(f"traderB.margin1 = {account_TRADER_B.margin}")
-    print(f"traderB.general1 = {account_TRADER_B.general}")
     market_data = vega.get_latest_market_data(market_id=market_id)
 
     _, estimate_liquidation_price_initial = vega.estimate_position(
@@ -565,15 +553,8 @@ def test_liquidation_price_witin_estimate_position_bounds_AC002(
         is_market_order=[True],
         collateral_available=collateral,
     )
-    # assert estimate_liquidation_price_initial.best_case.open_volume_only == estimate_liquidation_price_MO.best_case.including_sell_orders
-    print(
-        f"estimate_liquidation_price.best_case.open_volume_only={ estimate_liquidation_price_initial.best_case.open_volume_only}"
-    )
-    print(
-        f"estimate_liquidation_price.worst_case.open_volume_only={ estimate_liquidation_price_initial.worst_case.open_volume_only}"
-    )
 
-    for price in [519, 520, 521.5, 522]:
+    for price in [519, 520, 543, 543.5]:
         move_market(
             vega=vega,
             market_id=market_id,

--- a/tests/integration/test_visualisations.py
+++ b/tests/integration/test_visualisations.py
@@ -5,12 +5,14 @@ from tests.integration.utils.fixtures import vega_service
 from vega_sim.null_service import VegaServiceNull
 
 from examples.visualisations.closed_out import CloseOutVisualisation
+from examples.visualisations.auction_exit import AuctionExitVisualisation
 from examples.visualisations.loss_socialisation import LossSocialisationVisualisation
 
 
 @pytest.mark.integration
 def test_closed_out(vega_service: VegaServiceNull):
-    vis = CloseOutVisualisation(vega_service)
+    vega = vega_service
+    vis = CloseOutVisualisation(vega=vega)
     vis.test()
 
 
@@ -18,4 +20,11 @@ def test_closed_out(vega_service: VegaServiceNull):
 def test_loss_socialisation(vega_service: VegaServiceNull):
     vega = vega_service
     vis = LossSocialisationVisualisation(vega=vega)
+    vis.test()
+
+
+@pytest.mark.integration
+def test_auction_exit(vega_service: VegaServiceNull):
+    vega = vega_service
+    vis = AuctionExitVisualisation(vega=vega)
     vis.test()


### PR DESCRIPTION
### Description
PR adds an `AuctionExitVisualisation` visualisation which shows a market entering and exiting a price monitoring auction.

Example command for running visualisation with console and break points:
```
python -m examples.visualisations.auction_exit --console --pause
```

In CI parties trading in auctions have their trades checked to ensure they incur no fees.
