### PR TITLE
feat: Adding check for CI tags on PRs

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -102,3 +102,21 @@ jobs:
             echo $LATEST_REQ
             exit 1
           fi
+
+  check_version_tags:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.10"
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+
+      - name: Check Vega core version tags are up-to-date
+        run: |
+          poetry run scripts/check_tagged_versions.py

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -119,4 +119,4 @@ jobs:
 
       - name: Check Vega core version tags are up-to-date
         run: |
-          poetry run scripts/check_tagged_versions.py
+          poetry run python scripts/check_tagged_versions.py

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -116,7 +116,26 @@ jobs:
 
       - name: Install Poetry
         uses: snok/install-poetry@v1
+        with:
+          virtualenvs-create: true
+          virtualenvs-in-project: true
 
+      #----------------------------------------------
+      #       load cached venv if cache exists
+      #----------------------------------------------
+      - name: Load cached venv
+        id: cached-poetry-dependencies
+        uses: actions/cache@v2
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
+      #----------------------------------------------
+      # install dependencies if cache does not exist
+      #----------------------------------------------
+      - name: Install dependencies
+        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+        run: poetry install --no-interaction
+      #----------------------------------------------
       - name: Check Vega core version tags are up-to-date
         run: |
           poetry run python scripts/check_tagged_versions.py

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
     tags:
       - "v*.*.*" # Push events to matching v*, i.e. v1.0, v20.15.10
       - "!v*-snapshot"
+      - "!vega*"
 
 jobs:
   release:

--- a/.github/workflows/release_test.yml
+++ b/.github/workflows/release_test.yml
@@ -5,6 +5,7 @@ on:
     # Sequence of patterns matched against refs/tags
     tags:
       - "v*-snapshot" # Push events to matching v*, i.e. v1.0, v20.15.10
+      - "!vega*"
 
 jobs:
   release:

--- a/scripts/check_tagged_versions.py
+++ b/scripts/check_tagged_versions.py
@@ -24,10 +24,6 @@ def check_versions():
         if tag["name"].startswith("vega-"):
             tagged_vega_versions.add(tag["name"][5:])
 
-    if tagged_vega_versions.difference(versions_to_check):
-        raise Exception(
-            f"There are tags for non-existent vega versions: {tagged_vega_versions}"
-        )
     if versions_to_check.difference(tagged_vega_versions):
         raise Exception(f"Missing tags for vega versions: {versions_to_check}")
 

--- a/scripts/check_tagged_versions.py
+++ b/scripts/check_tagged_versions.py
@@ -1,0 +1,36 @@
+import requests
+
+EARLIEST_VERSION_TO_CHECK = "v0.73.8"
+
+
+def check_versions():
+    vega_versions = requests.get(
+        "https://api.github.com/repos/vegaprotocol/vega/releases"
+    ).json()
+    versions_to_check = set()
+    for version in vega_versions:
+        if version["tag_name"] == EARLIEST_VERSION_TO_CHECK:
+            versions_to_check.add(version["tag_name"])
+            break
+        if version["prerelease"]:
+            continue
+        versions_to_check.add(version["tag_name"])
+
+    tags = requests.get(
+        "https://api.github.com/repos/vegaprotocol/vega-market-sim/tags"
+    ).json()
+    tagged_vega_versions = set()
+    for tag in tags:
+        if tag["name"].startswith("vega-"):
+            tagged_vega_versions.add(tag["name"][5:])
+
+    if tagged_vega_versions.difference(versions_to_check):
+        raise Exception(
+            f"There are tags for non-existent vega versions: {tagged_vega_versions}"
+        )
+    if versions_to_check.difference(tagged_vega_versions):
+        raise Exception(f"Missing tags for vega versions: {versions_to_check}")
+
+
+if __name__ == "__main__":
+    check_versions()


### PR DESCRIPTION
### Description
<!---
What is the change?
--->

Adding a check to the actions run on a new PR to ensure recent Vega versions have a matching tag in market sim. If they do not, we error so as not to make further changes before finding a working version for the current release.

### Testing
<!---
How has the change been tested? Were new unit/integration tests added and do current ones cover?
--->

Tested locally

### Breaking Changes
<!---
Are any of the changes in this PR breaking/requiring of a change in workflow?
--->

### Closes
<!---
Does this close any issues?
--->
