### PR TITLE
fix: retry faucet calls

### DIFF
--- a/vega_sim/api/faucet.py
+++ b/vega_sim/api/faucet.py
@@ -1,3 +1,4 @@
+import time
 import requests
 from logging import getLogger
 
@@ -13,9 +14,13 @@ def mint(pub_key: str, asset: str, amount: int, faucet_url: str) -> None:
         "amount": str(int(amount)),
         "asset": asset,
     }
-    req = requests.post(url, json=payload)
-    try:
-        req.raise_for_status()
-    except Exception as e:
-        logger.exception(f"Exception in minting: {req.json()}")
-        raise e
+    for i in range(20):
+        try:
+            req = requests.post(url, json=payload)
+            req.raise_for_status()
+            return
+        except Exception as e:
+            time.sleep(0.1 * 1.2**i)
+
+    logger.exception(f"Exception in minting with payload {payload}: {req.json()}")
+    raise e


### PR DESCRIPTION
### Description
CI crashing after the faucets attempted connection to the core API is rejected.

```
[2023-12-08T09:14:15.719Z] ERROR    vega_sim.api.faucet:faucet.py:20 Exception in minting: {'error': 'rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial tcp [::1]:38665: connect: connection refused"'}
```


PR adds an exponential wait between faucet calls to investigate if core will eventually accept the faucet calls. The total wait time before raising an exception is `~=18.7s`
