### PR TITLE
feat: competing market makers scenario

### DIFF
--- a/tests/vega_sim/api/test_market.py
+++ b/tests/vega_sim/api/test_market.py
@@ -9,6 +9,6 @@ def test_market_config_instrument():
     assert config.is_future()
     assert not config.is_perp()
 
-    config = MarketConfig(opt="perp")
+    config = MarketConfig(opt="perpetual")
     assert not config.is_future()
     assert config.is_perp()

--- a/vega_sim/api/market.py
+++ b/vega_sim/api/market.py
@@ -30,15 +30,15 @@ A MarketConfig class has the following attributes which can be set:
 • instrument.future.quote_name
 • instrument.future.number_decimal_places
 • instrument.future.terminating_key
-• instrument.perp.settlement_asset
-• instrument.perp.quote_name
-• instrument.perp.number_decimal_places
-• instrument.perp.settlement_key
-• instrument.perp.funding_payment_frequency_in_seconds
-• instrument.perp.margin_funding_factor
-• instrument.perp.interest_rate
-• instrument.perp.clamp_lower_bound
-• instrument.perp.clamp_upper_bound
+• instrument.perpetual.settlement_asset
+• instrument.perpetual.quote_name
+• instrument.perpetual.number_decimal_places
+• instrument.perpetual.settlement_key
+• instrument.perpetual.funding_payment_frequency_in_seconds
+• instrument.perpetual.margin_funding_factor
+• instrument.perpetual.interest_rate
+• instrument.perpetual.clamp_lower_bound
+• instrument.perpetual.clamp_upper_bound
 
 
 Examples:
@@ -129,14 +129,14 @@ class MarketConfig(Config):
             "liquidity_sla_parameters": "default",
             "liquidation_strategy": "default",
         },
-        "perp": {
+        "perpetual": {
             "decimal_places": 4,
             "position_decimal_places": 2,
             "metadata": None,
             "price_monitoring_parameters": "default",
             "liquidity_monitoring_parameters": "default",
             "log_normal": "default",
-            "instrument": "perp",
+            "instrument": "perpetual",
             "linear_slippage_factor": 1e-3,
             "quadratic_slippage_factor": 0,
             "successor": None,
@@ -202,7 +202,7 @@ class MarketConfig(Config):
         return self.instrument.future is not None
 
     def is_perp(self) -> bool:
-        return self.instrument.perp is not None
+        return self.instrument.perpetual is not None
 
 
 class Successor(Config):
@@ -423,13 +423,13 @@ class InstrumentConfiguration(Config):
             "name": None,
             "code": None,
             "future": "default",
-            "perp": None,
+            "perpetual": None,
         },
-        "perp": {
+        "perpetual": {
             "name": None,
             "code": None,
             "future": None,
-            "perp": "default",
+            "perpetual": "default",
         },
     }
 
@@ -441,8 +441,10 @@ class InstrumentConfiguration(Config):
         self.future = (
             None if config["future"] is None else FutureProduct(opt=config["future"])
         )
-        self.perp = (
-            None if config["perp"] is None else PerpetualProduct(opt=config["perp"])
+        self.perpetual = (
+            None
+            if config["perpetual"] is None
+            else PerpetualProduct(opt=config["perpetual"])
         )
 
     def build(self):
@@ -450,9 +452,9 @@ class InstrumentConfiguration(Config):
             return vega_protos.governance.InstrumentConfiguration(
                 name=self.name, code=self.code, future=self.future.build()
             )
-        if self.perp != None:
+        if self.perpetual != None:
             return vega_protos.governance.InstrumentConfiguration(
-                name=self.name, code=self.code, perpetual=self.perp.build()
+                name=self.name, code=self.code, perpetual=self.perpetual.build()
             )
         raise ValueError("No product specified for the instrument")
 

--- a/vega_sim/local_data_cache.py
+++ b/vega_sim/local_data_cache.py
@@ -671,8 +671,11 @@ class LocalDataCache:
                     and acct.type != vega_protos.vega.AccountType.ACCOUNT_TYPE_GENERAL
                 ):
                     continue
-                if market_id is None and acct.market_id != "":
-                    continue
+                # TODO: Temporarily remove this to allow from feed to pull all accounts.
+                # if market_id is None and acct.market_id != "":
+                #     if acct.type == 19:
+                #         print("continue 3")
+                #     continue
                 if asset_id is not None and acct.asset != asset_id:
                     continue
                 results.append(acct)

--- a/vega_sim/scenario/competing_market_makers/plot.py
+++ b/vega_sim/scenario/competing_market_makers/plot.py
@@ -1,0 +1,68 @@
+import argparse
+
+from vega_sim.tools.scenario_plots import plot_account_by_party
+
+import vega_sim.proto.vega as vega_protos
+
+
+import matplotlib.pyplot as plt
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
+from matplotlib.gridspec import GridSpec
+
+
+def init_liquidation_analysis_figure() -> Figure:
+    fig = plt.figure(figsize=[11.69, 8.27])
+    fig.suptitle(
+        f"Tau Scaling Analysis",
+        fontsize=18,
+        fontweight="bold",
+        color=(0.2, 0.2, 0.2),
+    )
+    fig.tight_layout()
+
+    gs = GridSpec(
+        nrows=2,
+        ncols=1,
+        hspace=0.3,
+    )
+    return fig, gs
+
+
+if __name__ == "__main__":
+    fig: Figure = None
+    (fig, gs) = init_liquidation_analysis_figure()
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-r", "--runs", nargs="+")
+    args = parser.parse_args()
+
+    plot_account_by_party(
+        run_name=args.runs[0],
+        fig=fig,
+        ss=gs[0, 0],
+        account_type=vega_protos.vega.ACCOUNT_TYPE_LP_LIQUIDITY_FEES,
+    )
+    plot_account_by_party(
+        run_name=args.runs[1],
+        fig=fig,
+        ss=gs[1, 0],
+        account_type=vega_protos.vega.ACCOUNT_TYPE_LP_LIQUIDITY_FEES,
+    )
+    axes = fig.get_axes()
+    for ax in axes:
+        ax.set_ylim(bottom=0, top=6000)
+    axes[0].set_title(
+        "market.liquidity.probabilityOfTrading.tau.scaling=1",
+        loc="left",
+        fontsize=12,
+        color=(0.3, 0.3, 0.3),
+    )
+    axes[1].set_title(
+        "market.liquidity.probabilityOfTrading.tau.scaling=10",
+        loc="left",
+        fontsize=12,
+        color=(0.3, 0.3, 0.3),
+    )
+
+    plt.show()

--- a/vega_sim/scenario/competing_market_makers/scenario.py
+++ b/vega_sim/scenario/competing_market_makers/scenario.py
@@ -1,0 +1,322 @@
+import numpy as np
+from typing import Optional, List, Dict
+
+from vega_sim.api.market import MarketConfig
+from vega_sim.scenario.scenario import Scenario
+from vega_sim.scenario.constants import Network
+from vega_sim.null_service import VegaServiceNull
+from vega_sim.scenario.configurable_market.agents import ConfigurableMarketManager
+from vega_sim.scenario.common.utils.price_process import random_walk
+from vega_sim.environment.environment import (
+    MarketEnvironmentWithState,
+    NetworkEnvironment,
+)
+from vega_sim.scenario.common.agents import (
+    StateAgent,
+    UncrossAuctionAgent,
+    MarketOrderTrader,
+    LimitOrderTrader,
+    UniformLiquidityProvider,
+)
+
+# Mainnet market configuration as of 21/12/2023
+BTCUSDPERP = {
+    "decimalPlaces": 1,
+    "positionDecimalPlaces": 4,
+    "instrument": {
+        "code": "BTC/USD-PERP",
+        "perpetual": {
+            "quoteName": "USD",
+            "marginFundingFactor": "0.9",
+            "interestRate": "0.1095",
+            "clampLowerBound": "-0.0005",
+            "clampUpperBound": "0.0005",
+            "dataSourceSpecForSettlementSchedule": {
+                "internal": {
+                    "timeTrigger": {
+                        "conditions": [
+                            {"operator": "OPERATOR_GREATER_THAN_OR_EQUAL", "value": "0"}
+                        ],
+                        "triggers": [{"initial": "1701727200", "every": "28800"}],
+                    }
+                }
+            },
+            "dataSourceSpecForSettlementData": {
+                "external": {
+                    "ethOracle": {
+                        "address": "0xF4030086522a5bEEa4988F8cA5B36dbC97BeE88c",
+                        "abi": '[{"inputs":[],"name":"latestAnswer","outputs":[{"internalType":"int256","name":"","type":"int256"}],"stateMutability":"view","type":"function"}]',
+                        "method": "latestAnswer",
+                        "args": [],
+                        "trigger": {
+                            "timeTrigger": {"initial": "1701727200", "every": "300"}
+                        },
+                        "requiredConfirmations": "3",
+                        "filters": [
+                            {
+                                "key": {
+                                    "name": "btc.price",
+                                    "type": "TYPE_INTEGER",
+                                    "numberDecimalPlaces": "8",
+                                },
+                                "conditions": [
+                                    {"operator": "OPERATOR_GREATER_THAN", "value": "0"}
+                                ],
+                            }
+                        ],
+                        "normalisers": [{"name": "btc.price", "expression": "$[0]"}],
+                    }
+                }
+            },
+            "dataSourceSpecBinding": {
+                "settlementDataProperty": "btc.price",
+                "settlementScheduleProperty": "vegaprotocol.builtin.timetrigger",
+            },
+        },
+    },
+    "metadata": [
+        "base:BTC",
+        "quote:USDT",
+        "class:fx/crypto",
+        "perpetual",
+        "sector:defi",
+        "enactment:2023-12-01T18:00:00Z",
+    ],
+    "priceMonitoringParameters": {
+        "triggers": [
+            {"horizon": "4320", "probability": "0.9999999", "auctionExtension": "300"},
+            {"horizon": "1440", "probability": "0.9999999", "auctionExtension": "180"},
+            {"horizon": "360", "probability": "0.9999999", "auctionExtension": "120"},
+        ]
+    },
+    "liquidityMonitoringParameters": {
+        "targetStakeParameters": {"timeWindow": "3600", "scalingFactor": 0.05},
+        "triggeringRatio": "0.1",
+        "auctionExtension": "1",
+    },
+    "logNormal": {
+        "riskAversionParameter": 0.000001,
+        "tau": 0.000003995,
+        "params": {"mu": 0, "r": 0, "sigma": 1},
+    },
+    "linearSlippageFactor": "0.001",
+    "quadraticSlippageFactor": "0",
+    "liquiditySlaParameters": {
+        "priceRange": "0.03",
+        "commitmentMinTimeFraction": "0.85",
+        "performanceHysteresisEpochs": "1",
+        "slaCompetitionFactor": "0.5",
+    },
+}
+
+
+class CompetingMarketMakers(Scenario):
+    def __init__(
+        self,
+        num_steps: int = 3000,
+        transactions_per_block: int = 4096,
+        block_length_seconds: float = 1,
+        step_length_seconds: Optional[float] = None,
+        market_name: str = "CompetingMarketMakers",
+        market_code: str = "CMM",
+        asset_name: str = "USDT",
+        asset_decimals: int = 18,
+        output: bool = True,
+        market_config: Optional[MarketConfig] = None,
+        lps_min_bps: List[float] = [1, 50],
+        lps_max_bps: List[float] = [50, 100],
+        lps_commitment_amount: List[float] = [5e6, 5e6],
+        tau_scaling: Optional[float] = 10,
+        epoch_length: Optional[str] = "10m",
+        distribution_time_step: Optional[str] = "1m",
+    ):
+        super().__init__()
+
+        # Set simulation parameters
+        self.num_steps = num_steps
+        self.step_length_seconds = (
+            step_length_seconds
+            if step_length_seconds is not None
+            else block_length_seconds
+        )
+        self.block_length_seconds = block_length_seconds
+        self.transactions_per_block = transactions_per_block
+
+        # Set market parameters
+        self.market_name = market_name
+        self.market_code = market_code
+        self.asset_name = asset_name
+        self.asset_decimals = asset_decimals
+
+        if market_config is None:
+            self.market_config = MarketConfig()
+            self.market_config.load(BTCUSDPERP)
+            self.market_config.instrument.future = None
+
+        # Validate and set LP parameters
+        lengths = [
+            len(var) for var in [lps_min_bps, lps_max_bps, lps_commitment_amount]
+        ]
+        if lengths[:-1] != lengths[1:]:
+            raise ValueError(
+                "The lengths of 'lps_min_bps', 'lps_max_bps', and "
+                + "'lps_commitment_amount' must all be the same."
+            )
+        self.lps_min_bps = lps_min_bps
+        self.lps_max_bps = lps_max_bps
+        self.lps_commitment_amount = lps_commitment_amount
+
+        # Set network parameters
+        self.tau_scaling = tau_scaling
+        self.epoch_length = epoch_length
+        self.distribution_time_step = distribution_time_step
+
+        self.output = output
+
+    def configure_agents(
+        self,
+        vega: VegaServiceNull,
+        tag: str,
+        random_state: Optional[np.random.RandomState],
+        **kwargs,
+    ) -> List[StateAgent]:
+        self.random_state = (
+            random_state if random_state is not None else np.random.RandomState()
+        )
+
+        starting_price = 40000
+        price_process = random_walk(
+            num_steps=self.num_steps + 1,
+            sigma=0.1 * 0.001 * starting_price,
+            starting_price=starting_price,
+            decimal_precision=self.asset_decimals,
+        )
+
+        agents = []
+
+        agents.append(
+            ConfigurableMarketManager(
+                proposal_key_name="configurable_market_manager",
+                termination_key_name="configurable_market_manager",
+                market_config=self.market_config,
+                market_name=self.market_name,
+                market_code=self.market_code,
+                asset_name=self.asset_name,
+                asset_dp=self.asset_decimals,
+                settlement_price=price_process[-1],
+                network_parameters={
+                    "market.liquidity.probabilityOfTrading.tau.scaling": str(
+                        self.tau_scaling
+                    ),
+                    "market.liquidity.providersFeeCalculationTimeStep": self.distribution_time_step,
+                    "validators.epoch.length": self.epoch_length,
+                },
+            )
+        )
+        for min_bps, max_bps, commitment_amount in zip(
+            self.lps_min_bps, self.lps_max_bps, self.lps_commitment_amount
+        ):
+            agents.append(
+                UniformLiquidityProvider(
+                    key_name=f"mm_{min_bps}-{max_bps}",
+                    market_name=self.market_name,
+                    asset_name=self.asset_name,
+                    bps_range_min=min_bps,
+                    bps_range_max=max_bps,
+                    levels=50,
+                    fee=0.001,
+                    initial_asset_mint=commitment_amount * 10,
+                    commitment_amount=commitment_amount,
+                    tag=f"mm_{min_bps}-{max_bps}",
+                    random_state=random_state,
+                    price_process=iter(price_process),
+                )
+            )
+        agents.append(
+            UncrossAuctionAgent(
+                key_name="uncross_auction_agent_bid",
+                side="SIDE_BUY",
+                initial_asset_mint=1e9,
+                price_process=iter(price_process),
+                market_name=self.market_name,
+                asset_name=self.asset_name,
+                uncrossing_size=10**-self.market_config.position_decimal_places,
+                tag="bid",
+            )
+        )
+        agents.append(
+            UncrossAuctionAgent(
+                key_name="uncross_auction_agent_ask",
+                side="SIDE_SELL",
+                initial_asset_mint=1e9,
+                price_process=iter(price_process),
+                market_name=self.market_name,
+                asset_name=self.asset_name,
+                uncrossing_size=10**-self.market_config.position_decimal_places,
+                tag="ask",
+            )
+        )
+        agents.append(
+            MarketOrderTrader(
+                key_name="market_order_trader",
+                market_name=self.market_name,
+                asset_name=self.asset_name,
+                buy_intensity=10,
+                sell_intensity=10,
+                base_order_size=10**-self.market_config.position_decimal_places,
+                step_bias=1,
+            )
+        )
+        [
+            agents.append(
+                LimitOrderTrader(
+                    key_name="limit_order_trader",
+                    market_name=self.market_name,
+                    asset_name=self.asset_name,
+                    time_in_force_opts={"TIME_IN_FORCE_GTT": 1},
+                    buy_volume=10**-self.market_config.position_decimal_places,
+                    sell_volume=10**-self.market_config.position_decimal_places,
+                    buy_intensity=10,
+                    sell_intensity=10,
+                    submit_bias=1,
+                    cancel_bias=0,
+                    duration=5,
+                    price_process=price_process,
+                    spread=0,
+                    mean=-3,
+                    sigma=0.5,
+                    tag=i,
+                )
+            )
+            for i in range(10)
+        ]
+
+        return {agent.name: agent for agent in agents}
+
+    def configure_environment(
+        self,
+        vega: VegaServiceNull,
+        **kwargs,
+    ) -> MarketEnvironmentWithState:
+        if kwargs.get("network", Network.NULLCHAIN) == Network.NULLCHAIN:
+            return MarketEnvironmentWithState(
+                agents=list(self.agents.values()),
+                n_steps=self.num_steps,
+                random_agent_ordering=False,
+                transactions_per_block=self.transactions_per_block,
+                vega_service=vega,
+                step_length_seconds=self.step_length_seconds,
+                block_length_seconds=vega.seconds_per_block,
+            )
+        else:
+            return NetworkEnvironment(
+                agents=list(self.agents.values()),
+                n_steps=self.num_steps,
+                vega_service=vega,
+                step_length_seconds=self.step_length_seconds,
+                raise_datanode_errors=kwargs.get("raise_datanode_errors", False),
+                raise_step_errors=kwargs.get("raise_step_errors", False),
+                random_state=self.random_state,
+                create_keys=True,
+                mint_keys=True,
+            )

--- a/vega_sim/scenario/fuzzed_markets/agents.py
+++ b/vega_sim/scenario/fuzzed_markets/agents.py
@@ -982,11 +982,11 @@ class FuzzySuccessorConfigurableMarketManager(StateAgentWithWallet):
                 ),
             )
         if mkt_config.is_perp():
-            mkt_config.set("instrument.perp.settlement_asset", self.asset_id)
-            mkt_config.set("instrument.perp.quote_name", self.asset_name)
-            mkt_config.set("instrument.perp.number_decimal_places", self.asset_dp)
+            mkt_config.set("instrument.perpetual.settlement_asset", self.asset_id)
+            mkt_config.set("instrument.perpetual.quote_name", self.asset_name)
+            mkt_config.set("instrument.perpetual.number_decimal_places", self.asset_dp)
             mkt_config.set(
-                "instrument.perp.settlement_key",
+                "instrument.perpetual.settlement_key",
                 self.vega.wallet.public_key(
                     wallet_name=self.termination_wallet_name,
                     name=self._get_termination_key_name(),
@@ -995,25 +995,26 @@ class FuzzySuccessorConfigurableMarketManager(StateAgentWithWallet):
             if self.perp_options != None:
                 if self.perp_options.funding_payment_frequency_in_seconds != None:
                     mkt_config.set(
-                        "instrument.perp.funding_payment_frequency_in_seconds"
+                        "instrument.perpetual.funding_payment_frequency_in_seconds"
                     )
                 if self.perp_options.margin_funding_factor != None:
                     mkt_config.set(
-                        "instrument.perp.margin_funding_factor",
+                        "instrument.perpetual.margin_funding_factor",
                         self.perp_options.margin_funding_factor,
                     )
                 if self.perp_options.interest_rate != None:
                     mkt_config.set(
-                        "instrument.perp.interest_rate", self.perp_options.interest_rate
+                        "instrument.perpetual.interest_rate",
+                        self.perp_options.interest_rate,
                     )
                 if self.perp_options.clamp_lower_bound != None:
                     mkt_config.set(
-                        "instrument.perp.clamp_lower_bound",
+                        "instrument.perpetual.clamp_lower_bound",
                         self.perp_options.clamp_lower_bound,
                     )
                 if self.perp_options.clamp_upper_bound != None:
                     mkt_config.set(
-                        "instrument.perp.clamp_upper_bound",
+                        "instrument.perpetual.clamp_upper_bound",
                         self.perp_options.clamp_upper_bound,
                     )
 

--- a/vega_sim/scenario/fuzzed_markets/scenario.py
+++ b/vega_sim/scenario/fuzzed_markets/scenario.py
@@ -228,7 +228,7 @@ class FuzzingScenario(Scenario):
 
             market_agents = {}
             # Create fuzzed market config
-            market_config = MarketConfig("perp" if perps_market else None)
+            market_config = MarketConfig("perpetual" if perps_market else None)
             market_config.set(
                 "liquidity_monitoring_parameters.target_stake_parameters.scaling_factor",
                 1e-4,

--- a/vega_sim/scenario/registry.py
+++ b/vega_sim/scenario/registry.py
@@ -14,6 +14,7 @@ from vega_sim.scenario.parameter_experiment.scenario import ParameterExperiment
 from vega_sim.scenario.fuzzed_markets.scenario import FuzzingScenario
 from vega_sim.scenario.sla.scenario import SLAScenario
 from vega_sim.scenario.liquidations.scenario import LiquidationScenario
+from vega_sim.scenario.competing_market_makers.scenario import CompetingMarketMakers
 
 
 from vega_sim.scenario.common.utils.price_process import (
@@ -207,7 +208,7 @@ SCENARIOS = {
         transactions_per_block=4096,
     ),
     "sla_a": lambda: SLAScenario(
-        num_steps=3000,
+        num_steps=1000,
         step_length_seconds=1,
         block_length_seconds=1,
         transactions_per_block=4096,
@@ -250,6 +251,30 @@ SCENARIOS = {
         lps_offset=[0.5, 0.8],
         lps_target_time_on_book=[0.91, 0.91],
         lps_commitment_amount=[100000, 100000],
+    ),
+    "tau_scaling_1": lambda: CompetingMarketMakers(
+        num_steps=1200,
+        step_length_seconds=1,
+        block_length_seconds=1,
+        transactions_per_block=4096,
+        lps_min_bps=[0.1, 0.1],
+        lps_max_bps=[1, 10],
+        lps_commitment_amount=[1e6, 1e6],
+        tau_scaling=1,
+        epoch_length="10m",
+        distribution_time_step="5s",
+    ),
+    "tau_scaling_10": lambda: CompetingMarketMakers(
+        num_steps=1200,
+        step_length_seconds=1,
+        block_length_seconds=1,
+        transactions_per_block=4096,
+        lps_min_bps=[0.1, 0.1],
+        lps_max_bps=[1, 10],
+        lps_commitment_amount=[1e6, 1e6],
+        tau_scaling=10,
+        epoch_length="10m",
+        distribution_time_step="5s",
     ),
     "liquidation_small_degens": lambda: LiquidationScenario(
         num_steps=600,

--- a/vega_sim/tools/scenario_plots.py
+++ b/vega_sim/tools/scenario_plots.py
@@ -984,7 +984,7 @@ def plot_account_by_party(
     ss: Optional[GridSpecFromSubplotSpec] = None,
     asset_id: Optional[str] = None,
     market_id: Optional[str] = None,
-    account_type: Optional[vega_protos.vega.AccountType] = None,
+    account_type: Optional[vega_protos.vega.AccountType.Value] = None,
 ):
     # Get account data
     accounts = load_accounts_df(run_name=run_name).set_index(

--- a/vega_sim/tools/scenario_plots.py
+++ b/vega_sim/tools/scenario_plots.py
@@ -978,6 +978,87 @@ def reward_plots(run_name: Optional[str] = None):
     return fig
 
 
+def plot_account_by_party(
+    run_name: Optional[str] = None,
+    fig: Optional[Figure] = None,
+    ss: Optional[GridSpecFromSubplotSpec] = None,
+    asset_id: Optional[str] = None,
+    market_id: Optional[str] = None,
+    account_type: Optional[vega_protos.vega.AccountType] = None,
+):
+    # Get account data
+    accounts = load_accounts_df(run_name=run_name).set_index(
+        ["asset", "market_id", "type"], append=True
+    )
+    # Create a boolean mask based on conditions
+    mask = (
+        (
+            accounts.index.get_level_values("asset") == asset_id
+            if asset_id is not None
+            else True
+        )
+        & (
+            accounts.index.get_level_values("market_id") == market_id
+            if market_id is not None
+            else True
+        )
+        & (
+            accounts.index.get_level_values("type") == account_type
+            if account_type is not None
+            else True
+        )
+    )
+    # Apply the mask using loc
+    accounts = accounts.loc[mask]
+
+    if fig is None:
+        fig = plt.figure(figsize=[10, 8])
+        fig.suptitle(
+            f"Accounts Plot",
+            fontsize=18,
+            fontweight="bold",
+            color=(0.2, 0.2, 0.2),
+        )
+        fig.tight_layout()
+    if ss is None:
+        gs = GridSpec(
+            nrows=1,
+            ncols=1,
+        )
+    else:
+        gs = GridSpecFromSubplotSpec(
+            subplot_spec=ss,
+            nrows=1,
+            ncols=1,
+        )
+
+    axs: list[plt.Axes] = []
+    axs.append(fig.add_subplot(gs[0, 0]))
+    axs[-1].set_title(
+        (f"asset: {asset_id[:6]} | " if asset_id is not None else "")
+        + (f"market: {market_id[:6]} | " if market_id is not None else "")
+        + (
+            f"account_type: {vega_protos.vega.AccountType.Name(account_type)}"
+            if account_type is not None
+            else ""
+        ),
+        loc="left",
+        fontsize=12,
+        color=(0.3, 0.3, 0.3),
+    )
+    final_values = (
+        accounts.groupby("party_id")["balance"].last().sort_values(ascending=False)
+    )
+    for party in final_values.index.values:
+        group = accounts[accounts["party_id"] == party]
+        axs[-1].step(
+            group.index.get_level_values(0),
+            group["balance"],
+            label=(party[:5] if party != "network" else "network"),
+        )
+    axs[-1].legend()
+
+
 def sla_plot(run_name: Optional[str] = None):
     accounts_df = load_accounts_df(run_name=run_name)
     ledger_entries_df = load_ledger_entries_df(run_name=run_name)


### PR DESCRIPTION
### Description:

PR adds a `CompetingMarketMakers` which allows any number of configurable `UniformLiquidityProvider` to provide liquidity in a market with a number of random traders.

Scenarios can be used to investigate the effect of varying `market.liquidity.probabilityOfTrading.tau.scaling`:

### Example:

1. Run a preconfigured scenario with `market.liquidity.probabilityOfTrading.tau.scaling=1`
```
python -m vega_sim.scenario.adhoc -s tau_scaling_1 --output
```
2. Once the run is complete rename the scenario outputs:
```
mv run_logs/latest run_logs/tauscaling1
```

3. Run a preconfigured scenario with `market.liquidity.probabilityOfTrading.tau.scaling=10`
```
python -m vega_sim.scenario.adhoc -s tau_scaling_10 --output
```
4. Once the run is complete rename the scenario outputs:
```
mv run_logs/latest run_logs/tauscaling10
```

5. Generate the plot to compare the results:
```
python -m vega_sim.scenario.competing_market_makers.plot --runs tauscaling1 tauscaling10

```
<img width="1027" alt="image" src="https://github.com/vegaprotocol/vega-market-sim/assets/99198652/d1ee4734-0c67-4310-868a-a3f32717f38b">

