### PR TITLE
feat: incraese grpc message size, and add pfice feed multiplier feature

### DIFF
--- a/vega_sim/devops/classes.py
+++ b/vega_sim/devops/classes.py
@@ -33,7 +33,7 @@ class MarketMakerArgs:
     fee_amount: float
     commitment_amount: int
     initial_mint: Optional[int] = MAX_FAUCET
-    isolated_margin_factor: Optional[float]
+    isolated_margin_factor: Optional[float] = None
 
 
 @dataclass

--- a/vega_sim/devops/classes.py
+++ b/vega_sim/devops/classes.py
@@ -33,6 +33,7 @@ class MarketMakerArgs:
     fee_amount: float
     commitment_amount: int
     initial_mint: Optional[int] = MAX_FAUCET
+    isolated_margin_factor: Optional[float]
 
 
 @dataclass

--- a/vega_sim/devops/scenario.py
+++ b/vega_sim/devops/scenario.py
@@ -133,7 +133,9 @@ class DevOpsScenario(Scenario):
                 random_state=random_state
             )
         else:
-            self.price_process = get_live_price(product=self.binance_code, multiplier=self.feed_price_multiplier)
+            self.price_process = get_live_price(
+                product=self.binance_code, multiplier=self.feed_price_multiplier
+            )
 
         if self.scenario_wallet.market_creator_agent is None:
             raise ValueError(

--- a/vega_sim/devops/scenario.py
+++ b/vega_sim/devops/scenario.py
@@ -54,6 +54,7 @@ class DevOpsScenario(Scenario):
     def __init__(
         self,
         binance_code: str,
+        feed_price_multiplier: int,
         market_manager_args: MarketManagerArgs,
         market_maker_args: MarketMakerArgs,
         auction_trader_args: AuctionTraderArgs,
@@ -70,6 +71,7 @@ class DevOpsScenario(Scenario):
         super().__init__(state_extraction_fn=state_extraction_fn)
 
         self.binance_code = binance_code
+        self.feed_price_multiplier = feed_price_multiplier
 
         self.market_manager_args = market_manager_args
         self.market_maker_args = market_maker_args
@@ -131,7 +133,7 @@ class DevOpsScenario(Scenario):
                 random_state=random_state
             )
         else:
-            self.price_process = get_live_price(product=self.binance_code)
+            self.price_process = get_live_price(product=self.binance_code, multiplier=self.feed_price_multiplier)
 
         if self.scenario_wallet.market_creator_agent is None:
             raise ValueError(

--- a/vega_sim/devops/scenario.py
+++ b/vega_sim/devops/scenario.py
@@ -192,7 +192,7 @@ class DevOpsScenario(Scenario):
                 orders_from_stream=False,
                 state_update_freq=10,
                 tag=None,
-                isolated_margin_factor=0.1,
+                isolated_margin_factor=self.market_maker_args.isolated_margin_factor,
             )
 
             # Setup agents for passing opening auction

--- a/vega_sim/devops/scenario.py
+++ b/vega_sim/devops/scenario.py
@@ -54,12 +54,12 @@ class DevOpsScenario(Scenario):
     def __init__(
         self,
         binance_code: str,
-        feed_price_multiplier: int,
         market_manager_args: MarketManagerArgs,
         market_maker_args: MarketMakerArgs,
         auction_trader_args: AuctionTraderArgs,
         random_trader_args: RandomTraderArgs,
         sensitive_trader_args: SensitiveTraderArgs,
+        feed_price_multiplier: int = 1,
         simulation_args: Optional[SimulationArgs] = None,
         state_extraction_fn: Optional[
             Callable[[VegaServiceNull, Dict[str, Agent]], Any]

--- a/vega_sim/devops/scenario.py
+++ b/vega_sim/devops/scenario.py
@@ -27,7 +27,7 @@ from vega_sim.environment.environment import (
     Agent,
 )
 from vega_sim.scenario.common.utils.price_process import (
-    LivePrice,
+    get_live_price,
     get_historic_price_series,
 )
 from vega_sim.scenario.common.agents import (
@@ -202,6 +202,7 @@ class DevOpsScenario(Scenario):
                         else self.market_manager_args.market_name
                     ),
                     asset_name=self.market_manager_args.asset_name,
+                    opening_auction_trade_amount=self.auction_trader_args.initial_volume,
                     initial_asset_mint=self.auction_trader_args.initial_mint,
                     initial_price=self.price_process[0],
                     side=["SIDE_BUY", "SIDE_SELL"][i],

--- a/vega_sim/grpc/client.py
+++ b/vega_sim/grpc/client.py
@@ -21,9 +21,8 @@ class GRPCClient(ABC):
             channel = grpc.insecure_channel(
                 self.url,
                 options=[
-                    ("grpc.max_message_length", 1024 * 1024 * 128),
-                    ("grpc.max_send_message_length", 1024 * 1024 * 128),
-                    ("grpc.max_receive_message_length", 1024 * 1024 * 128),
+                    ("grpc.max_send_message_length", 1024 * 1024 * 64),
+                    ("grpc.max_receive_message_length", 1024 * 1024 * 64),
                 ],
             )
             grpc.channel_ready_future(channel).result(timeout=10)

--- a/vega_sim/grpc/client.py
+++ b/vega_sim/grpc/client.py
@@ -21,8 +21,9 @@ class GRPCClient(ABC):
             channel = grpc.insecure_channel(
                 self.url,
                 options=[
-                    ("grpc.max_send_message_length", 1024 * 1024 * 20),
-                    ("grpc.max_receive_message_length", 1024 * 1024 * 20),
+                    ("grpc.max_message_length", 1024 * 1024 * 128),
+                    ("grpc.max_send_message_length", 1024 * 1024 * 128),
+                    ("grpc.max_receive_message_length", 1024 * 1024 * 128),
                 ],
             )
             grpc.channel_ready_future(channel).result(timeout=10)

--- a/vega_sim/network_service.py
+++ b/vega_sim/network_service.py
@@ -618,8 +618,8 @@ class VegaServiceNetwork(VegaService):
                     self.data_node_grpc_url,
                     options=(
                         ("grpc.enable_http_proxy", 0),
-                        ("grpc.max_send_message_length", 1024 * 1024 * 20),
-                        ("grpc.max_receive_message_length", 1024 * 1024 * 20),
+                        ("grpc.max_send_message_length", 1024 * 1024 * 128),
+                        ("grpc.max_receive_message_length", 1024 * 1024 * 128),
                     ),
                 )
                 grpc.channel_ready_future(channel).result(timeout=30)

--- a/vega_sim/network_service.py
+++ b/vega_sim/network_service.py
@@ -618,8 +618,8 @@ class VegaServiceNetwork(VegaService):
                     self.data_node_grpc_url,
                     options=(
                         ("grpc.enable_http_proxy", 0),
-                        ("grpc.max_send_message_length", 1024 * 1024 * 128),
-                        ("grpc.max_receive_message_length", 1024 * 1024 * 128),
+                        ("grpc.max_send_message_length", 1024 * 1024 * 64),
+                        ("grpc.max_receive_message_length", 1024 * 1024 * 64),
                     ),
                 )
                 grpc.channel_ready_future(channel).result(timeout=30)

--- a/vega_sim/null_service.py
+++ b/vega_sim/null_service.py
@@ -960,8 +960,8 @@ class VegaServiceNull(VegaService):
                         self.data_node_grpc_url,
                         options=(
                             ("grpc.enable_http_proxy", 0),
-                            ("grpc.max_send_message_length", 1024 * 1024 * 20),
-                            ("grpc.max_receive_message_length", 1024 * 1024 * 20),
+                            ("grpc.max_send_message_length", 1024 * 1024 * 128),
+                            ("grpc.max_receive_message_length", 1024 * 1024 * 128),
                         ),
                     )
                     grpc.channel_ready_future(channel).result(timeout=5)

--- a/vega_sim/null_service.py
+++ b/vega_sim/null_service.py
@@ -960,8 +960,8 @@ class VegaServiceNull(VegaService):
                         self.data_node_grpc_url,
                         options=(
                             ("grpc.enable_http_proxy", 0),
-                            ("grpc.max_send_message_length", 1024 * 1024 * 128),
-                            ("grpc.max_receive_message_length", 1024 * 1024 * 128),
+                            ("grpc.max_send_message_length", 1024 * 1024 * 64),
+                            ("grpc.max_receive_message_length", 1024 * 1024 * 64),
                         ),
                     )
                     grpc.channel_ready_future(channel).result(timeout=5)

--- a/vega_sim/scenario/common/utils/price_process.py
+++ b/vega_sim/scenario/common/utils/price_process.py
@@ -249,7 +249,7 @@ def get_live_price(product: str, multiplier: int) -> LivePrice:
 
     with _live_prices_lock:
         if not feed_key in _live_prices:
-            _live_prices[feed_key] = LivePrice(product=product, multiplier = multiplier)
+            _live_prices[feed_key] = LivePrice(product=product, multiplier=multiplier)
         return _live_prices[feed_key]
 
 

--- a/vega_sim/scenario/common/utils/price_process.py
+++ b/vega_sim/scenario/common/utils/price_process.py
@@ -210,9 +210,10 @@ class LivePrice:
 
     """
 
-    def __init__(self, product: str = "BTCBUSD"):
+    def __init__(self, product: str = "BTCBUSD", multiplier: int = 1):
         self.product = product
         self.latest_price = None
+        self.multiplier = multiplier
 
         self._forwarding_thread = threading.Thread(
             target=_price_listener,
@@ -233,20 +234,23 @@ class LivePrice:
     def _get_price(self):
         while self.latest_price is None:
             time.sleep(0.33)
-        return self.latest_price
+        return self.latest_price * self.multiplier
 
 
 _live_prices = {}
 _live_prices_lock = threading.Lock()
 
 
-def get_live_price(product: str) -> LivePrice:
+def get_live_price(product: str, multiplier: int) -> LivePrice:
     global _live_prices
     global _live_prices_lock
+
+    feed_key = f"{product}_{multiplier}"
+
     with _live_prices_lock:
-        if not product in _live_prices:
-            _live_prices[product] = LivePrice(product=product)
-        return _live_prices[product]
+        if not feed_key in _live_prices:
+            _live_prices[feed_key] = LivePrice(product=product, multiplier = multiplier)
+        return _live_prices[feed_key]
 
 
 if __name__ == "__main__":

--- a/vega_sim/service.py
+++ b/vega_sim/service.py
@@ -294,8 +294,8 @@ class VegaService(ABC):
                 self.data_node_grpc_url,
                 options=(
                     ("grpc.enable_http_proxy", 0),
-                    ("grpc.max_send_message_length", 1024 * 1024 * 20),
-                    ("grpc.max_receive_message_length", 1024 * 1024 * 20),
+                    ("grpc.max_send_message_length", 1024 * 1024 * 128),
+                    ("grpc.max_receive_message_length", 1024 * 1024 * 128),
                 ),
             )
             grpc.channel_ready_future(channel).result(timeout=30)
@@ -312,8 +312,8 @@ class VegaService(ABC):
                 self.vega_node_grpc_url,
                 options=(
                     ("grpc.enable_http_proxy", 0),
-                    ("grpc.max_send_message_length", 1024 * 1024 * 20),
-                    ("grpc.max_receive_message_length", 1024 * 1024 * 20),
+                    ("grpc.max_send_message_length", 1024 * 1024 * 128),
+                    ("grpc.max_receive_message_length", 1024 * 1024 * 128),
                 ),
             )
 
@@ -331,8 +331,8 @@ class VegaService(ABC):
                 self.vega_node_grpc_url,
                 options=(
                     ("grpc.enable_http_proxy", 0),
-                    ("grpc.max_send_message_length", 1024 * 1024 * 20),
-                    ("grpc.max_receive_message_length", 1024 * 1024 * 20),
+                    ("grpc.max_send_message_length", 1024 * 1024 * 128),
+                    ("grpc.max_receive_message_length", 1024 * 1024 * 128),
                 ),
             )
 

--- a/vega_sim/service.py
+++ b/vega_sim/service.py
@@ -294,8 +294,8 @@ class VegaService(ABC):
                 self.data_node_grpc_url,
                 options=(
                     ("grpc.enable_http_proxy", 0),
-                    ("grpc.max_send_message_length", 1024 * 1024 * 128),
-                    ("grpc.max_receive_message_length", 1024 * 1024 * 128),
+                    ("grpc.max_send_message_length", 1024 * 1024 * 64),
+                    ("grpc.max_receive_message_length", 1024 * 1024 * 64),
                 ),
             )
             grpc.channel_ready_future(channel).result(timeout=30)
@@ -312,8 +312,8 @@ class VegaService(ABC):
                 self.vega_node_grpc_url,
                 options=(
                     ("grpc.enable_http_proxy", 0),
-                    ("grpc.max_send_message_length", 1024 * 1024 * 128),
-                    ("grpc.max_receive_message_length", 1024 * 1024 * 128),
+                    ("grpc.max_send_message_length", 1024 * 1024 * 64),
+                    ("grpc.max_receive_message_length", 1024 * 1024 * 64),
                 ),
             )
 
@@ -331,8 +331,8 @@ class VegaService(ABC):
                 self.vega_node_grpc_url,
                 options=(
                     ("grpc.enable_http_proxy", 0),
-                    ("grpc.max_send_message_length", 1024 * 1024 * 128),
-                    ("grpc.max_receive_message_length", 1024 * 1024 * 128),
+                    ("grpc.max_send_message_length", 1024 * 1024 * 64),
+                    ("grpc.max_receive_message_length", 1024 * 1024 * 64),
                 ),
             )
 


### PR DESCRIPTION
### Description

- fixed issues with renamed functions for price_feed in the devops package
- increased GRPC message size to 64MB - We need it for bots that are running in the fairground, the responses are huge(e.g.: for list transfers)
- added the multiplier for price feed. We need it for the `1000xPEPE market` designed by @jeremyletang. We use proxy contract on the ethereum mainnet that multiplies price times 1000, and we need to do the same with the Binance feed.

### Testing

Bots are already running this version on stagnet & fairground

### Breaking Changes

N/A

