### PR TITLE
feat: default to last success

### DIFF
--- a/vega_sim/scenario/fuzzed_markets/agents.py
+++ b/vega_sim/scenario/fuzzed_markets/agents.py
@@ -1158,6 +1158,7 @@ class FuzzySuccessorConfigurableMarketManager(StateAgentWithWallet):
                 self.market_id = self.vega.find_market_id(
                     name=self._get_market_name(), raise_on_missing=True
                 )
+                self.market_config = mkt_config
                 return
 
             except (

--- a/vega_sim/scenario/fuzzed_markets/scenario.py
+++ b/vega_sim/scenario/fuzzed_markets/scenario.py
@@ -153,7 +153,6 @@ class FuzzingScenario(Scenario):
         output: bool = True,
         lite: bool = False,
     ):
-
         super().__init__(
             state_extraction_fn=lambda vega, agents: state_extraction_fn(vega, agents),
             additional_data_output_fns={


### PR DESCRIPTION
If the fuzzed market proposer is unable to propose a market successfully, currently it proposes the market-sim default market. Since there is already a separate chain of default sensible markets this adds no value.

Instead, it should propose the last successful fuzzed config.