### PR TITLE
fix: default seed for auction exit visualisations

### DIFF
--- a/examples/visualisations/auction_exit.py
+++ b/examples/visualisations/auction_exit.py
@@ -45,7 +45,7 @@ TRADER_B = PartyConfig(wallet_name=WALLET_NAME, key_name="Trader B Party")
 class AuctionExitVisualisation(Visualisation):
     START_PRICE = 500
 
-    SEED = None
+    SEED = 1
 
     def run(self, pause: bool = False, test: bool = False):
         # Setup a market and move it into a continuous trading state


### PR DESCRIPTION
Currently test generates a random price series before attempting to trigger an auction. Some seeds yield a price series which do not result in an auction. This causes occasional CI failures on develop.

PR simply fixes the seed so an auction is always triggered for this visualisation test.