### PR TITLE
feat: add check for crossed book

### DIFF
--- a/vega_sim/environment/environment.py
+++ b/vega_sim/environment/environment.py
@@ -277,7 +277,7 @@ class MarketEnvironment:
             if step_end_callback is not None:
                 step_end_callback()
             # TODO: Reduce frequency of check once isolated margin issues resolved
-            vega.check_book_not_crossed(raise_exceptions=False)
+            vega.check_book_not_crossed(raise_exceptions=True)
 
         vega.check_balances_equal_deposits()
         logger.info(f"Run took {(datetime.datetime.now() - start).seconds}s")

--- a/vega_sim/environment/environment.py
+++ b/vega_sim/environment/environment.py
@@ -276,6 +276,8 @@ class MarketEnvironment:
                 )
             if step_end_callback is not None:
                 step_end_callback()
+            # TODO: Reduce frequency of check once isolated margin issues resolved
+            vega.check_book_not_crossed(raise_exceptions=False)
 
         vega.check_balances_equal_deposits()
         logger.info(f"Run took {(datetime.datetime.now() - start).seconds}s")

--- a/vega_sim/service.py
+++ b/vega_sim/service.py
@@ -3630,7 +3630,7 @@ class VegaService(ABC):
             max_bid = max(market_depth.buys, key=lambda x: x.price)
             min_ask = min(market_depth.sells, key=lambda x: x.price)
             try:
-                assert max_bid_price.price < min_ask_price.price
+                assert max_bid.price < min_ask.price
                 logging.debug(
                     f"Market {market_id[:6]} in TRADING_MODE_CONTINUOUS and greatest bid < smallest ask ({max_bid.price:.2f} < {min_ask.price:.2f})"
                 )

--- a/vega_sim/service.py
+++ b/vega_sim/service.py
@@ -3627,22 +3627,17 @@ class VegaService(ABC):
             )
             if market_depth.buys == [] or market_depth.sells == []:
                 continue
-            max_bid = max(market_depth.buys, key=lambda x: x.price)
-            min_ask = min(market_depth.sells, key=lambda x: x.price)
+            max_bid_price = max(market_depth.buys, key=lambda x: x.price).price
+            min_ask_price = min(market_depth.sells, key=lambda x: x.price).price
             try:
                 assert max_bid.price < min_ask.price
                 logging.debug(
-                    f"Market {market_id[:6]} in TRADING_MODE_CONTINUOUS and greatest bid < smallest ask ({max_bid.price:.2f} < {min_ask.price:.2f})"
+                    f"Market {market_id[:6]} in TRADING_MODE_CONTINUOUS and greatest bid < smallest ask ({max_bid_price:.2f} < {min_ask_price:.2f})"
                 )
             except AssertionError as e:
                 logging.error(
-                    f"Market {market_id[:6]} in TRADING_MODE_CONTINUOUS but greatest bid > smallest ask ({max_bid.id} {max_bid.size}@{max_bid.price} > {min_ask.id} {min_ask.size}@{min_ask.price})"
+                    f"Market {market_id[:6]} in TRADING_MODE_CONTINUOUS but greatest bid > smallest ask ({max_bid_price} > {min_ask_price})"
                 )
-                for b in market_depth.buys:
-                    logging.error(f"buy:{b.id} {b.size}@{b.price}")
-                for o in market_depth.sells:
-                    logging.error(f"sell:{o.id} {o.size}@{o.price}")
-                
                 if raise_exceptions:
                     raise e
 

--- a/vega_sim/service.py
+++ b/vega_sim/service.py
@@ -3640,7 +3640,7 @@ class VegaService(ABC):
                 )
                 for b in market_depth.buys:
                     logging.error(f"buy:{b.id} {b.size}@{b.price}")
-                for o in in market_depth.sells:
+                for o in market_depth.sells:
                     logging.error(f"sell:{o.id} {o.size}@{o.price}")
                 
                 if raise_exceptions:

--- a/vega_sim/service.py
+++ b/vega_sim/service.py
@@ -3627,16 +3627,16 @@ class VegaService(ABC):
             )
             if market_depth.buys == [] or market_depth.sells == []:
                 continue
-            max_bid_price = max(market_depth.buys, key=lambda x: x.price).price
-            min_ask_price = min(market_depth.sells, key=lambda x: x.price).price
+            max_bid = max(market_depth.buys, key=lambda x: x.price)
+            min_ask = min(market_depth.sells, key=lambda x: x.price)
             try:
-                assert max_bid_price < min_ask_price
+                assert max_bid_price.price < min_ask_price.price
                 logging.debug(
-                    f"Market {market_id[:6]} in TRADING_MODE_CONTINUOUS and greatest bid < smallest ask ({max_bid_price:.2f} < {min_ask_price:.2f})"
+                    f"Market {market_id[:6]} in TRADING_MODE_CONTINUOUS and greatest bid < smallest ask ({max_bid.price:.2f} < {min_ask.price:.2f})"
                 )
             except AssertionError as e:
                 logging.error(
-                    f"Market {market_id[:6]} in TRADING_MODE_CONTINUOUS but greatest bid > smallest ask ({max_bid_price:.2f} > {min_ask_price:.2f})"
+                    f"Market {market_id[:6]} in TRADING_MODE_CONTINUOUS but greatest bid > smallest ask ({max_bid.id} {max_bid.size}@{max_bid.price} > {min_ask.id} {min_ask.size}@{min_ask.price})"
                 )
                 for b in market_depth.buys:
                     logging.error(f"buy:{b.id} {b.size}@{b.price}")

--- a/vega_sim/service.py
+++ b/vega_sim/service.py
@@ -3638,6 +3638,11 @@ class VegaService(ABC):
                 logging.error(
                     f"Market {market_id[:6]} in TRADING_MODE_CONTINUOUS but greatest bid > smallest ask ({max_bid_price:.2f} > {min_ask_price:.2f})"
                 )
+                for b in market_depth.buys:
+                    logging.error(f"buy:{b.id} {b.size}@{b.price}")
+                for o in in market_depth.sells:
+                    logging.error(f"sell:{o.id} {o.size}@{o.price}")
+                
                 if raise_exceptions:
                     raise e
 

--- a/vega_sim/service.py
+++ b/vega_sim/service.py
@@ -3630,13 +3630,13 @@ class VegaService(ABC):
             max_bid_price = max(market_depth.buys, key=lambda x: x.price).price
             min_ask_price = min(market_depth.sells, key=lambda x: x.price).price
             try:
-                assert max_bid.price < min_ask.price
+                assert max_bid_price < min_ask_price
                 logging.debug(
                     f"Market {market_id[:6]} in TRADING_MODE_CONTINUOUS and greatest bid < smallest ask ({max_bid_price:.2f} < {min_ask_price:.2f})"
                 )
             except AssertionError as e:
                 logging.error(
-                    f"Market {market_id[:6]} in TRADING_MODE_CONTINUOUS but greatest bid > smallest ask ({max_bid_price} > {min_ask_price})"
+                    f"Market {market_id} in TRADING_MODE_CONTINUOUS but greatest bid > smallest ask ({max_bid_price} > {min_ask_price})"
                 )
                 if raise_exceptions:
                     raise e


### PR DESCRIPTION
Isolated margin will be enabled again on develop for the overnight fuzzing runs.

PR adds a check asserting the order book is not crossed whilst the market is in continuous trading.