### PR TITLE
feat: alternative datanode sync

### DIFF
--- a/vega_sim/null_service.py
+++ b/vega_sim/null_service.py
@@ -1086,6 +1086,10 @@ class VegaServiceNull(VegaService):
         return self._build_url(self.vega_node_port)
 
     @property
+    def vega_node_rest_url(self) -> str:
+        return self._build_url(self.vega_node_rest_port)
+
+    @property
     def vega_node_grpc_url(self) -> str:
         return self._build_url(self.vega_node_grpc_port, prefix="")
 


### PR DESCRIPTION
### Description
In long fuzzing tests, runs are consistently failing in the same place. Waiting for datanode to sync after making a governance transfer proposal.

- https://jenkins.vega.rocks/job/common/job/vega-market-sim-reinforcement/334/execution/node/177/log/
- https://jenkins.vega.rocks/job/common/job/vega-market-sim-reinforcement/329/execution/node/177/log/
- https://jenkins.vega.rocks/job/common/job/vega-market-sim-reinforcement/328/execution/node/177/log/
- https://jenkins.vega.rocks/job/common/job/vega-market-sim-reinforcement/327/execution/node/177/log/
- https://jenkins.vega.rocks/job/common/job/vega-market-sim-reinforcement/326/execution/node/177/log/
- https://jenkins.vega.rocks/job/common/job/vega-market-sim-reinforcement/325/execution/node/177/log/

```
13:59:35  Traceback (most recent call last):
13:59:35    File "<frozen runpy>", line 198, in _run_module_as_main
13:59:35    File "<frozen runpy>", line 88, in _run_code
13:59:35    File "/jenkins/workspace/common/vega-market-sim-reinforcement/vega_sim/scenario/fuzzed_markets/run_fuzz_test.py", line 111, in <module>
13:59:35      _run(
13:59:35    File "/jenkins/workspace/common/vega-market-sim-reinforcement/vega_sim/scenario/fuzzed_markets/run_fuzz_test.py", line 52, in _run
13:59:35      scenario.run_iteration(
13:59:35    File "/jenkins/workspace/common/vega-market-sim-reinforcement/vega_sim/scenario/scenario.py", line 106, in run_iteration
13:59:35      outputs = self.env.run(
13:59:35                ^^^^^^^^^^^^^
13:59:35    File "/jenkins/workspace/common/vega-market-sim-reinforcement/vega_sim/environment/environment.py", line 168, in run
13:59:35      return self._run(
13:59:35             ^^^^^^^^^^
13:59:35    File "/jenkins/workspace/common/vega-market-sim-reinforcement/vega_sim/environment/environment.py", line 238, in _run
13:59:35      self.step(vega)
13:59:35    File "/jenkins/workspace/common/vega-market-sim-reinforcement/vega_sim/environment/environment.py", line 430, in step
13:59:35      agent.step(state)
13:59:35    File "/jenkins/workspace/common/vega-market-sim-reinforcement/vega_sim/scenario/fuzzed_markets/agents.py", line 1552, in step
13:59:35      self.vega.submit_proposal(
13:59:35    File "/jenkins/workspace/common/vega-market-sim-reinforcement/vega_sim/service.py", line 3563, in submit_proposal
13:59:35      proposal_id = gov.submit_proposal(
13:59:35                    ^^^^^^^^^^^^^^^^^^^^
13:59:35    File "/jenkins/workspace/common/vega-market-sim-reinforcement/vega_sim/api/governance.py", line 1147, in submit_proposal
13:59:35      proposal = _make_and_wait_for_proposal(
13:59:35                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
13:59:35    File "/jenkins/workspace/common/vega-market-sim-reinforcement/vega_sim/api/governance.py", line 827, in _make_and_wait_for_proposal
13:59:35      sync_fn()
13:59:35    File "/jenkins/workspace/common/vega-market-sim-reinforcement/vega_sim/service.py", line 3570, in <lambda>
13:59:35      sync_fn=lambda: self.wait_for_total_catchup(),
13:59:35                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
13:59:35    File "/jenkins/workspace/common/vega-market-sim-reinforcement/vega_sim/service.py", line 364, in wait_for_total_catchup
13:59:35      self.wait_for_datanode_sync()
13:59:35    File "/jenkins/workspace/common/vega-market-sim-reinforcement/vega_sim/service.py", line 342, in wait_for_datanode_sync
13:59:35      wait_for_datanode_sync(self.trading_data_client_v2, self.core_client)
13:59:35    File "/jenkins/workspace/common/vega-market-sim-reinforcement/vega_sim/api/helpers.py", line 95, in wait_for_datanode_sync
13:59:35      raise DataNodeBehindError(
13:59:35  vega_sim.api.helpers.DataNodeBehindError: Data Node is behind and not catching up after 100 retries
```

To unblock fuzzing runs PR switches the datanode sync method to a more reliable block height check and increases the total wait from `~60s` -> `~300s`. If datanode does not sync, an error is logged but not raised.

Not raising an issue may result in errors when proposing markets / assets / programs later down the line as datanode may be hanging but this is an accepted risk for now.

<img width="610" alt="Screenshot 2024-02-27 at 07 46 40" src="https://github.com/vegaprotocol/vega-market-sim/assets/99198652/3b6a9327-9041-49e8-ad31-6e0e156aac1b">

Will re-investigate issue once higher priority work finished.

