### PR TITLE
chore: remove unnecessary block forwarding

### DIFF
--- a/vega_sim/scenario/common/agents.py
+++ b/vega_sim/scenario/common/agents.py
@@ -147,7 +147,7 @@ class MarketOrderTrader(StateAgentWithWallet):
                 amount=self.initial_asset_mint,
                 wallet_name=self.wallet_name,
             )
-        self.vega.wait_fn(5)
+
         self.pdp = self.vega.market_pos_decimals.get(self.market_id, {})
         self.mdp = self.vega.market_price_decimals.get(self.market_id, {})
         self.adp = self.vega.asset_decimals.get(self.asset_id, {})
@@ -253,7 +253,6 @@ class PriceSensitiveMarketOrderTrader(StateAgentWithWallet):
                 amount=self.initial_asset_mint,
                 wallet_name=self.wallet_name,
             )
-        self.vega.wait_fn(5)
 
     def step(self, vega_state: VegaState):
         self.curr_price = next(self.price_process_generator)
@@ -362,7 +361,6 @@ class PriceSensitiveLimitOrderTrader(StateAgentWithWallet):
                 amount=self.initial_asset_mint,
                 wallet_name=self.wallet_name,
             )
-        self.vega.wait_fn(5)
 
     def step(self, vega_state: VegaState):
         self.curr_price = next(self.price_process_generator)
@@ -894,7 +892,7 @@ class OpenAuctionPass(StateAgentWithWallet):
                 amount=self.initial_asset_mint,
                 key_name=self.key_name,
             )
-        self.vega.wait_fn(10)
+
         self.vega.wait_for_total_catchup()
 
         self.vega.submit_order(
@@ -974,7 +972,7 @@ class MarketManager(StateAgentWithWallet):
             amount=1e4,
             key_name=self.key_name,
         )
-        self.vega.wait_fn(5)
+
         self.vega.wait_for_total_catchup()
         if vega.find_asset_id(symbol=self.asset_name) is None:
             # Create asset
@@ -985,7 +983,7 @@ class MarketManager(StateAgentWithWallet):
                 decimals=self.adp,
                 key_name=self.key_name,
             )
-        self.vega.wait_fn(5)
+
         self.vega.wait_for_total_catchup()
         # Get asset id
         self.asset_id = self.vega.find_asset_id(symbol=self.asset_name)
@@ -997,7 +995,6 @@ class MarketManager(StateAgentWithWallet):
                 amount=self.initial_mint,
                 key_name=self.key_name,
             )
-        self.vega.wait_fn(5)
 
         self.vega.wait_for_total_catchup()
         # Set up a future market
@@ -3167,7 +3164,7 @@ class UncrossAuctionAgent(StateAgentWithWallet):
                 amount=self.initial_asset_mint,
                 key_name=self.key_name,
             )
-        self.vega.wait_fn(10)
+
         self.vega.wait_for_total_catchup()
 
     def step(self, vega_state: VegaState):

--- a/vega_sim/scenario/fuzzed_markets/agents.py
+++ b/vega_sim/scenario/fuzzed_markets/agents.py
@@ -73,8 +73,6 @@ class FuzzingAgent(StateAgentWithWallet):
                 wallet_name=self.wallet_name,
             )
 
-        self.vega.wait_fn(5)
-
     def step(self, vega_state):
         self.live_orders = self.vega.orders_for_party_from_feed(
             key_name=self.key_name,
@@ -312,8 +310,6 @@ class RiskyMarketOrderTrader(StateAgentWithWallet):
                 wallet_name=self.wallet_name,
             )
 
-        self.vega.wait_fn(5)
-
     def step(self, vega_state):
         account = self.vega.party_account(
             key_name=self.key_name,
@@ -418,8 +414,6 @@ class RiskySimpleLiquidityProvider(StateAgentWithWallet):
                 amount=self.initial_asset_mint,
                 wallet_name=self.wallet_name,
             )
-
-        self.vega.wait_fn(5)
 
     def step(self, vega_state):
         account = self.vega.party_account(
@@ -547,8 +541,6 @@ class FuzzyLiquidityProvider(StateAgentWithWallet):
                 amount=self.initial_asset_mint,
                 wallet_name=self.wallet_name,
             )
-
-        self.vega.wait_fn(5)
 
     def _gen_spec(self, side: vega_protos.vega.Side, is_valid: bool):
         refs = [
@@ -702,8 +694,6 @@ class SuccessorMarketCreatorAgent(StateAgentWithWallet):
                 amount=self.initial_asset_mint,
                 wallet_name=self.wallet_name,
             )
-
-        self.vega.wait_fn(5)
 
 
 class PerpProductOptions(NamedTuple):

--- a/vega_sim/scenario/ideal_market_maker/agents.py
+++ b/vega_sim/scenario/ideal_market_maker/agents.py
@@ -144,7 +144,6 @@ class OptimalMarketMaker(StateAgentWithWallet):
             amount=1e4,
             key_name=self.key_name,
         )
-        self.vega.wait_fn(5)
 
         # Create asset
         self.vega.create_asset(
@@ -154,7 +153,7 @@ class OptimalMarketMaker(StateAgentWithWallet):
             decimals=self.adp,
             key_name=self.key_name,
         )
-        self.vega.wait_fn(5)
+
         self.vega.wait_for_total_catchup()
         # Get asset id
         self.asset_id = self.vega.find_asset_id(symbol=self.asset_name)

--- a/vega_sim/scenario/ideal_market_maker_v2/agents.py
+++ b/vega_sim/scenario/ideal_market_maker_v2/agents.py
@@ -140,7 +140,7 @@ class OptimalMarketMaker(StateAgentWithWallet):
         self.vega.create_key(self.terminate_key_name, self.wallet_name)
 
         # Faucet vega tokens
-        self.vega.wait_fn(10)
+
         self.vega.wait_for_total_catchup()
         self.vega.mint(
             wallet_name=self.wallet_name,
@@ -148,7 +148,7 @@ class OptimalMarketMaker(StateAgentWithWallet):
             amount=1e4,
             key_name=self.key_name,
         )
-        self.vega.wait_fn(10)
+
         self.vega.wait_for_total_catchup()
         if self.set_up_market:
             # Create asset
@@ -159,7 +159,7 @@ class OptimalMarketMaker(StateAgentWithWallet):
                 decimals=self.adp,
                 key_name=self.key_name,
             )
-            self.vega.wait_fn(5)
+
             self.vega.wait_for_total_catchup()
         # Get asset id
         self.asset_id = self.vega.find_asset_id(symbol=self.asset_name)
@@ -170,7 +170,7 @@ class OptimalMarketMaker(StateAgentWithWallet):
             amount=self.initial_asset_mint,
             key_name=self.key_name,
         )
-        self.vega.wait_fn(10)
+
         self.vega.wait_for_total_catchup()
 
         if self.set_up_market:


### PR DESCRIPTION
Currently agents forward blocks in multiple places after creating / minting assets. 

This makes it difficult to initialise a market without enacting it as subsequent agents initialising steps forward blocks (often to enactment).

PR removes redundant block forwarding.