### PR TITLE
feat: allow tick sizes greater than 1

### DIFF
--- a/vega_sim/api/helpers.py
+++ b/vega_sim/api/helpers.py
@@ -55,6 +55,7 @@ def num_from_padded_int(to_convert: Union[str, int], decimals: int) -> float:
 def round_to_tick(
     price: float, tick_size: int, side: Optional[Side.Value] = None
 ) -> float:
+    print(price, type(price))
     ticks = int(tick_size)
     if side == Side.SIDE_BUY:
         return int(math.floor(price / ticks) * ticks)

--- a/vega_sim/api/helpers.py
+++ b/vega_sim/api/helpers.py
@@ -52,7 +52,9 @@ def num_from_padded_int(to_convert: Union[str, int], decimals: int) -> float:
     return float(to_convert) / 10**decimals
 
 
-def round_to_tick(price: float, tick_size: int, side: Optional[Side] = None) -> float:
+def round_to_tick(
+    price: float, tick_size: int, side: Optional[Side.Value] = None
+) -> float:
     ticks = int(tick_size)
     if side == Side.SIDE_BUY:
         return int(math.floor(price / ticks) * ticks)

--- a/vega_sim/api/market.py
+++ b/vega_sim/api/market.py
@@ -158,7 +158,7 @@ class MarketConfig(Config):
             "liquidity_fee_settings": "default",
             "liquidation_strategy": "default",
             "mark_price_configuration": "default",
-            "tick_size": "2",
+            "tick_size": "1",
         },
         "future": {
             "decimal_places": 4,
@@ -175,7 +175,7 @@ class MarketConfig(Config):
             "liquidity_fee_settings": "default",
             "liquidation_strategy": "default",
             "mark_price_configuration": "default",
-            "tick_size": "2",
+            "tick_size": "1",
         },
         "perpetual": {
             "decimal_places": 4,
@@ -192,7 +192,7 @@ class MarketConfig(Config):
             "liquidity_fee_settings": "default",
             "liquidation_strategy": "default",
             "mark_price_configuration": "default",
-            "tick_size": "2",
+            "tick_size": "1",
         },
     }
 

--- a/vega_sim/api/market.py
+++ b/vega_sim/api/market.py
@@ -158,7 +158,7 @@ class MarketConfig(Config):
             "liquidity_fee_settings": "default",
             "liquidation_strategy": "default",
             "mark_price_configuration": "default",
-            "tick_size": "1",
+            "tick_size": "2",
         },
         "future": {
             "decimal_places": 4,
@@ -175,7 +175,7 @@ class MarketConfig(Config):
             "liquidity_fee_settings": "default",
             "liquidation_strategy": "default",
             "mark_price_configuration": "default",
-            "tick_size": "1",
+            "tick_size": "2",
         },
         "perpetual": {
             "decimal_places": 4,
@@ -192,7 +192,7 @@ class MarketConfig(Config):
             "liquidity_fee_settings": "default",
             "liquidation_strategy": "default",
             "mark_price_configuration": "default",
-            "tick_size": "1",
+            "tick_size": "2",
         },
     }
 

--- a/vega_sim/configs/mainnet/BTCUSDT.py
+++ b/vega_sim/configs/mainnet/BTCUSDT.py
@@ -10,7 +10,7 @@ CONFIG = MarketConfig(
     {
         "decimalPlaces": "1",
         "positionDecimalPlaces": "4",
-        "tickSize": "1",
+        "tickSize": "2",
         "instrument": {
             "code": "BTC/USDT",
             "name": "Bitcoin / Tether USD (Perpetual)",

--- a/vega_sim/configs/mainnet/ETHUSDT.py
+++ b/vega_sim/configs/mainnet/ETHUSDT.py
@@ -10,7 +10,7 @@ CONFIG = MarketConfig(
     {
         "decimalPlaces": "2",
         "positionDecimalPlaces": "3",
-        "tickSize": "1",
+        "tickSize": "2",
         "instrument": {
             "code": "ETH/USDT",
             "name": "Ether / Tether USD (Perpetual)",

--- a/vega_sim/configs/mainnet/INJUSDT.py
+++ b/vega_sim/configs/mainnet/INJUSDT.py
@@ -10,7 +10,7 @@ CONFIG = MarketConfig(
     {
         "decimalPlaces": "3",
         "positionDecimalPlaces": "1",
-        "tickSize": "1",
+        "tickSize": "2",
         "instrument": {
             "code": "INJ/USDT",
             "name": "Injective / Tether USD (Perpetual)",

--- a/vega_sim/configs/mainnet/LDOUSDT.py
+++ b/vega_sim/configs/mainnet/LDOUSDT.py
@@ -10,7 +10,7 @@ CONFIG = MarketConfig(
     {
         "decimalPlaces": "4",
         "positionDecimalPlaces": "1",
-        "tickSize": "1",
+        "tickSize": "2",
         "instrument": {
             "code": "LDO/USDT",
             "name": "Lido / Tether USD (Perpetual)",

--- a/vega_sim/configs/mainnet/SNXUSDT.py
+++ b/vega_sim/configs/mainnet/SNXUSDT.py
@@ -10,7 +10,7 @@ CONFIG = MarketConfig(
     {
         "decimalPlaces": "3",
         "positionDecimalPlaces": "1",
-        "tickSize": "1",
+        "tickSize": "2",
         "instrument": {
             "code": "SNX/USDT",
             "name": "Synthetix / Tether USD (Perpetual)",

--- a/vega_sim/configs/mainnet/SOLUSDT.py
+++ b/vega_sim/configs/mainnet/SOLUSDT.py
@@ -10,7 +10,7 @@ CONFIG = MarketConfig(
     {
         "decimalPlaces": "2",
         "positionDecimalPlaces": "1",
-        "tickSize": "1",
+        "tickSize": "2",
         "instrument": {
             "name": "Solana / Tether USD (Perpetual)",
             "code": "SOL/USDT",

--- a/vega_sim/configs/research/POINTS.py
+++ b/vega_sim/configs/research/POINTS.py
@@ -5,6 +5,7 @@ CONFIG = MarketConfig(
         "linearSlippageFactor": "0.001",
         "decimalPlaces": "5",
         "positionDecimalPlaces": "0",
+        "tick_size": "2",
         "instrument": {
             "name": "EigenLayer Points / USDT (Futures market)",
             "code": "EGLP/USDT.POINTS",
@@ -524,6 +525,5 @@ CONFIG = MarketConfig(
         "markPriceConfiguration": {
             "compositePriceType": "COMPOSITE_PRICE_TYPE_LAST_TRADE"
         },
-        "tick_size": 1,
     }
 )

--- a/vega_sim/service.py
+++ b/vega_sim/service.py
@@ -985,6 +985,7 @@ class VegaService(ABC):
         post_only: bool = False,
         peak_size: Optional[float] = None,
         minimum_visible_size: Optional[float] = None,
+        round_to_tick: bool = True,
     ) -> Optional[str]:
         """
         Submit orders as specified to required pre-existing market.
@@ -1057,6 +1058,14 @@ class VegaService(ABC):
             if price is not None
             else None
         )
+        if round_to_tick and price is not None:
+            # TODO: Implement tick size into the local data cache to avoid API calls
+            market = self.market_info(market_id)
+            submit_price = helpers.round_to_tick(
+                submit_price,
+                tick_size=market.tick_size,
+                side=side,
+            )
         if submit_price is not None and submit_price <= 0:
             msg = "Not submitting order as price is 0 or less."
             if wait:
@@ -1133,6 +1142,7 @@ class VegaService(ABC):
         volume_delta: float = 0,
         time_in_force: Optional[Union[vega_protos.vega.Order.TimeInForce, str]] = None,
         wallet_name: Optional[str] = None,
+        round_to_tick: bool = True,
     ):
         """
         Amend a Limit order by orderID in the specified market
@@ -1160,22 +1170,30 @@ class VegaService(ABC):
             wallet_name:
                 optional str, name of wallet to use
         """
+        price = (
+            str(
+                num_to_padded_int(
+                    price,
+                    self.market_price_decimals[market_id],
+                )
+            )
+            if price is not None
+            else None
+        )
+        # TODO: Implement tick size into the local data cache to avoid API calls
+        market = self.market_info(market_id)
+        if round_to_tick:
+            price = helpers.round_to_tick(
+                price,
+                tick_size=market.tick_size,
+            )
         trading.amend_order(
             wallet=self.wallet,
             key_name=trading_key,
             wallet_name=wallet_name,
             market_id=market_id,
             order_id=order_id,
-            price=(
-                str(
-                    num_to_padded_int(
-                        price,
-                        self.market_price_decimals[market_id],
-                    )
-                )
-                if price is not None
-                else None
-            ),
+            price=price,
             expires_at=expires_at,
             pegged_offset=(
                 str(
@@ -2473,6 +2491,7 @@ class VegaService(ABC):
         post_only: bool = False,
         pegged_order: Optional[vega_protos.vega.PeggedOrder] = None,
         iceberg_opts: Optional[vega_protos.commands.v1.commands.IcebergOpts] = None,
+        round_to_tick: bool = True,
     ) -> OrderSubmission:
         """Returns a Vega OrderSubmission object
 
@@ -2514,14 +2533,20 @@ class VegaService(ABC):
         """
 
         price = (
-            price
-            if price is None
-            else (
-                num_to_padded_int(
-                    to_convert=price, decimals=self.market_price_decimals[market_id]
-                )
+            num_to_padded_int(
+                to_convert=price, decimals=self.market_price_decimals[market_id]
             )
+            if price is not None
+            else None
         )
+        if round_to_tick:
+            # TODO: Implement tick size into the local data cache to avoid API calls
+            market = self.market_info(market_id)
+            price = helpers.round_to_tick(
+                price=price,
+                tick_size=market.tick_size,
+                side=side,
+            )
         size = (
             size
             if size is None

--- a/vega_sim/service.py
+++ b/vega_sim/service.py
@@ -1059,8 +1059,7 @@ class VegaService(ABC):
             else None
         )
         if round_to_tick and price is not None:
-            # TODO: Implement tick size into the local data cache to avoid API calls
-            market = self.market_info(market_id)
+            market = self.data_cache.market_from_feed(market_id)
             submit_price = helpers.round_to_tick(
                 submit_price,
                 tick_size=market.tick_size,
@@ -1180,8 +1179,7 @@ class VegaService(ABC):
             if price is not None
             else None
         )
-        # TODO: Implement tick size into the local data cache to avoid API calls
-        market = self.market_info(market_id)
+        market = self.data_cache.market_from_feed(market_id)
         if round_to_tick:
             price = helpers.round_to_tick(
                 price,
@@ -2540,8 +2538,7 @@ class VegaService(ABC):
             else None
         )
         if round_to_tick:
-            # TODO: Implement tick size into the local data cache to avoid API calls
-            market = self.market_info(market_id)
+            market = self.data_cache.market_from_feed(market_id)
             price = helpers.round_to_tick(
                 price=price,
                 tick_size=market.tick_size,

--- a/vega_sim/service.py
+++ b/vega_sim/service.py
@@ -1170,11 +1170,9 @@ class VegaService(ABC):
                 optional str, name of wallet to use
         """
         price = (
-            str(
-                num_to_padded_int(
-                    price,
-                    self.market_price_decimals[market_id],
-                )
+            num_to_padded_int(
+                price,
+                self.market_price_decimals[market_id],
             )
             if price is not None
             else None
@@ -1191,7 +1189,7 @@ class VegaService(ABC):
             wallet_name=wallet_name,
             market_id=market_id,
             order_id=order_id,
-            price=price,
+            price=str(price),
             expires_at=expires_at,
             pegged_offset=(
                 str(


### PR DESCRIPTION
Updates all service methods which submit/amend orders at prices to have an optional round to tick field. When true..
- prices of buy orders will be rounded down to nearest tick
- prices of sell orders will be rounded up to nearest tick

The tick size field of all existing configs is also updated so the feature is being covered.