### PR TITLE
fix: no margin mode for party

### DIFF
--- a/vega_sim/service.py
+++ b/vega_sim/service.py
@@ -3761,4 +3761,8 @@ class VegaService(ABC):
             party_id=self.wallet.public_key(name=key_name, wallet_name=wallet_name),
             market_id=market_id,
         )
-        return party_margin_modes[0] if party_margin_modes is not None else None
+        return (
+            party_margin_modes[0]
+            if (party_margin_modes is not None) and (party_margin_modes != [])
+            else None
+        )


### PR DESCRIPTION
Job [5564](https://jenkins.vega.rocks/blue/organizations/jenkins/common%2Fvega-market-sim/detail/vega-market-sim/5564/pipeline) failed as market-maker attempted to retrieve there margin mode when they not yet successfully updated their margin mode or opened a position on that market.

PR updates service method so we return `None` if no margin modes can be retreived.