### PR TITLE
feat: update epoch length at start of epoch

### DIFF
--- a/vega_sim/scenario/common/agents.py
+++ b/vega_sim/scenario/common/agents.py
@@ -97,6 +97,43 @@ class TradeSignal(Enum):
     SELL = 2
 
 
+class NetworkParameterManager(StateAgentWithWallet):
+    """Agent for updating network parameters at the start of a scenario."""
+
+    NAME_BASE = "network_parameter_manager"
+
+    def __init__(
+        self,
+        key_name: str,
+        network_parameters: Dict[str, Any],
+        wallet_name: Optional[str] = None,
+        tag: str = "",
+    ):
+        super().__init__(wallet_name=wallet_name, key_name=key_name, tag=tag)
+        self.network_parameters = network_parameters
+
+    def initialise(
+        self,
+        vega: Union[VegaServiceNull, VegaServiceNetwork],
+        create_key: bool = True,
+        mint_key: bool = True,
+    ):
+        super().initialise(vega=vega, create_key=create_key, mint_key=mint_key)
+        self.vega.mint(
+            wallet_name=self.wallet_name,
+            asset=self.vega.find_asset_id(symbol="VOTE", enabled=True),
+            amount=1e4,
+            key_name=self.key_name,
+        )
+        for key, value in self.network_parameters.items():
+            self.vega.update_network_parameter(
+                proposal_key=self.key_name,
+                wallet_name=self.wallet_name,
+                parameter=key,
+                new_value=str(value),
+            )
+
+
 class MarketOrderTrader(StateAgentWithWallet):
     NAME_BASE = "mo_trader"
 

--- a/vega_sim/scenario/fuzzed_markets/scenario.py
+++ b/vega_sim/scenario/fuzzed_markets/scenario.py
@@ -19,6 +19,7 @@ from vega_sim.null_service import VegaServiceNull
 
 from vega_sim.scenario.common.agents import (
     StateAgent,
+    NetworkParameterManager,
     UncrossAuctionAgent,
     ExponentialShapedMarketMaker,
     MarketOrderTrader,
@@ -189,6 +190,13 @@ class FuzzingScenario(Scenario):
 
         self.agents = []
         self.initial_asset_mint = 10e9
+
+        self.agents.append(
+            NetworkParameterManager(
+                key_name="NETWORK_PARAMETER_MANAGER",
+                network_parameters={"validators.epoch.length": "25m"},
+            )
+        )
 
         self.agents.append(
             FuzzyReferralProgramManager(


### PR DESCRIPTION
Adds a network parameter managing agent which can be used to update the values of network agents at the start of a scenario.

Can be used when updating genesis is not an option.