### PR TITLE
fix: sync before check

### DIFF
--- a/vega_sim/service.py
+++ b/vega_sim/service.py
@@ -3646,6 +3646,7 @@ class VegaService(ABC):
         )
 
     def check_market_states_consistent(self, raise_exceptions: bool = True):
+        self.wait_for_total_catchup()
         markets = self.all_markets()
         for market in markets:
             market_data = self.get_latest_market_data(market_id=market.id)


### PR DESCRIPTION
Ensures datanode is sync and finished processing blocks before making requests to different APIs.