### PR TITLE
feat: add retry check

### DIFF
--- a/vega_sim/service.py
+++ b/vega_sim/service.py
@@ -3645,18 +3645,30 @@ class VegaService(ABC):
             margin_factor=str(margin_factor),
         )
 
-    def check_market_states_consistent(self, raise_exceptions: bool = True):
+    def check_market_states_consistent(
+        self, raise_exceptions: bool = True, max_attempts: int = 5
+    ):
+        exception = None
         self.wait_for_total_catchup()
-        markets = self.all_markets()
-        for market in markets:
-            market_data = self.get_latest_market_data(market_id=market.id)
-            try:
-                assert market.state == market_data.market_state
-                assert market.trading_mode == market_data.market_trading_mode
-            except AssertionError as e:
-                if raise_exceptions:
-                    raise e
-                logging.error(e)
+        for _ in range(max_attempts):
+            markets = self.all_markets()
+            for market in markets:
+                market_data = self.get_latest_market_data(market_id=market.id)
+                try:
+                    assert market.state == market_data.market_state
+                    assert market.trading_mode == market_data.market_trading_mode
+                    return
+                except AssertionError as e:
+                    exception = e
+                    time.sleep(5)
+                    logging.warning(
+                        "Check failed, waiting to ensure sync then retrying check."
+                    )
+                    self.wait_for_total_catchup()
+                    continue
+        if raise_exceptions:
+            raise exception
+        logging.error(exception)
 
     def check_book_not_crossed(self, raise_exceptions: bool = True):
         # Check needs to ensure all services are synced.

--- a/vega_sim/service.py
+++ b/vega_sim/service.py
@@ -3665,10 +3665,10 @@ class VegaService(ABC):
                         "Check failed, waiting to ensure sync then retrying check."
                     )
                     self.wait_for_total_catchup()
-                    continue
+                    break
         if raise_exceptions:
             raise exception
-        logging.error(exception)
+        logger.error(exception)
 
     def check_book_not_crossed(self, raise_exceptions: bool = True):
         # Check needs to ensure all services are synced.


### PR DESCRIPTION
To ensure failed inconsistent market data checks are not a result of out of sync nodes still processing blocks, if a check fails, we wait a significant period and then retry the check.