### PR TITLE
feat: improve retry logic and logging for checks

### DIFF
--- a/vega_sim/environment/environment.py
+++ b/vega_sim/environment/environment.py
@@ -277,9 +277,9 @@ class MarketEnvironment:
             if step_end_callback is not None:
                 step_end_callback()
             # TODO: Reduce frequency of check once mainnet updated to v0.75.0
-            vega.check_book_not_crossed(raise_exceptions=True)
+            vega.check_book_not_crossed()
             # TODO: Reduce frequency of check once mainnet updated to v0.75.0
-            vega.check_market_states_consistent(raise_exceptions=True)
+            vega.check_market_states_consistent()
 
         vega.check_balances_equal_deposits()
         logger.info(f"Run took {(datetime.datetime.now() - start).seconds}s")


### PR DESCRIPTION
`check_market_states_consistent` and `check_book_not_crossed` occasionally fail and it is difficult to diagnose whether this is due to requests being made when the datanode is still processing blocks or a specific core issue.

PR makes following changes
- simplifies the retry logic by switching to a decorator and increases the number of attempts before raising errors.
- adds detailed logging messages so we can tell
  - the exact check failing
  - the values returned by each API
  - the datanode block height each request was made at (approximately). For an exact number here we should switch to using rest APIs for these checks which include the datanode block height in the headers. 