### PR TITLE
feat: Disable plotting in generic fuzz testing for now

### DIFF
--- a/vega_sim/scenario/fuzzed_markets/run_fuzz_test.py
+++ b/vega_sim/scenario/fuzzed_markets/run_fuzz_test.py
@@ -54,6 +54,7 @@ def _run(
             network=Network.NULLCHAIN,
             output_data=output,
             log_every_n_steps=100,
+            run_with_snitch=output,
         )
 
     if output:
@@ -111,7 +112,7 @@ if __name__ == "__main__":
     _run(
         steps=args.steps,
         console=args.console,
-        output=True,
+        output=False,
         lite=args.lite,
         core_metrics_port=args.core_metrics_port,
         data_node_metrics_port=args.data_node_metrics_port,


### PR DESCRIPTION
### Description
<!---
What is the change?
--->

Disabling plotting and snitch in fuzz testing to reduce memory usage.
These will be reenabled in a future release which improves the data collection logic

### Testing
<!---
How has the change been tested? Were new unit/integration tests added and do current ones cover?
--->

Ran locally, all worked fine

### Breaking Changes
<!---
Are any of the changes in this PR breaking/requiring of a change in workflow?
--->

### Closes
<!---
Does this close any issues?
--->
