### PR TITLE
feat: add configurable market termination time

### DIFF
--- a/tests/integration/test_governance.py
+++ b/tests/integration/test_governance.py
@@ -108,6 +108,7 @@ def test_create_simple_spot_market(vega_service: vega_service):
     )
 
 
+@pytest.mark.integration
 def test_market_termination_time(vega_service: VegaServiceNull):
     vega = vega_service
 

--- a/vega_sim/service.py
+++ b/vega_sim/service.py
@@ -950,6 +950,7 @@ class VegaService(ABC):
         forward_time_to_enactment: bool = True,
         parent_market_id: Optional[str] = None,
         parent_market_insurance_pool_fraction: float = 1,
+        termination_time: Optional[datetime.datetime] = None,
     ) -> str:
         """Creates a simple fixed-expiry futures market with a predefined reasonable set of parameters.
 
@@ -993,6 +994,10 @@ class VegaService(ABC):
                     parent_market_insurance_pool_fraction:
                         float, Fraction of parent market insurance pool to carry over.
                             defaults to 1. No-op if parent_market_id is not set.
+                    termination_time:
+                        Optional[datetime.datetime], If set, the time at which the
+                        market will be terminated. If not set, the market will be
+                        terminated via submitted data. Defaults to None.
         """
         additional_kwargs = {}
         if future_asset is not None:
@@ -1035,6 +1040,7 @@ class VegaService(ABC):
             price_monitoring_parameters=price_monitoring_parameters,
             parent_market_id=parent_market_id,
             parent_market_insurance_pool_fraction=parent_market_insurance_pool_fraction,
+            termination_time=int(termination_time.timestamp()),
             **additional_kwargs,
         )
         if approve_proposal:

--- a/vega_sim/service.py
+++ b/vega_sim/service.py
@@ -1040,7 +1040,11 @@ class VegaService(ABC):
             price_monitoring_parameters=price_monitoring_parameters,
             parent_market_id=parent_market_id,
             parent_market_insurance_pool_fraction=parent_market_insurance_pool_fraction,
-            termination_time=int(termination_time.timestamp()),
+            termination_time=(
+                int(termination_time.timestamp())
+                if termination_time is not None
+                else None
+            ),
             **additional_kwargs,
         )
         if approve_proposal:


### PR DESCRIPTION
Console-tests require the ability to configure a market termination trigger to be an internal time rather than an external data source.

PR adds this option and a test to confirm behaviour.