### PR TITLE
fix: reduce fuzzed transactions in fuzzing runs

### DIFF
--- a/vega_sim/scenario/fuzzed_markets/agents.py
+++ b/vega_sim/scenario/fuzzed_markets/agents.py
@@ -107,7 +107,7 @@ class FuzzingAgent(StateAgentWithWallet):
         self.curr_time = self.vega.get_blockchain_time(in_seconds=True)
 
         submissions = []
-        for _ in range(10):
+        for _ in range(5):
             submission = self.create_fuzzed_submission(vega_state)
             if submission is None:
                 continue
@@ -126,7 +126,7 @@ class FuzzingAgent(StateAgentWithWallet):
                 except AttributeError as e:
                     raise e
         amendments = []
-        for _ in range(10):
+        for _ in range(5):
             amendment = self.create_fuzzed_amendment(vega_state)
             if amendment is None:
                 continue
@@ -160,7 +160,7 @@ class FuzzingAgent(StateAgentWithWallet):
                 except HTTPError:
                     continue
         stop_orders_submissions = []
-        for _ in range(10):
+        for _ in range(5):
             stop_orders_submission = self.create_fuzzed_stop_orders_submission(
                 vega_state
             )

--- a/vega_sim/scenario/fuzzing/scenario.py
+++ b/vega_sim/scenario/fuzzing/scenario.py
@@ -91,7 +91,7 @@ class FuzzingScenario(BenchmarkScenario):
                     avatar_url=f"avatarUrl_{str(i_agent).zfill(3)}",
                     closed=False,
                 )
-                for i_agent in range(5)
+                for i_agent in range(3)
             ]
         )
 
@@ -117,7 +117,7 @@ class FuzzingScenario(BenchmarkScenario):
                         referrer_wallet_name="ReferralAgentWrapper",
                         referrer_key_name=f"ReferralAgentWrapper_{str(i_referrer).zfill(3)}",
                     )
-                    for i_referrer, i_agent in itertools.product(range(5), range(2))
+                    for i_referrer, i_agent in itertools.product(range(2), range(2))
                 ]
             )
             extra_agents.extend(
@@ -135,7 +135,7 @@ class FuzzingScenario(BenchmarkScenario):
                         referrer_wallet_name="ReferralAgentWrapper",
                         referrer_key_name=f"ReferralAgentWrapper_{str(i_referrer).zfill(3)}",
                     )
-                    for i_referrer, i_agent in itertools.product(range(5), range(2))
+                    for i_referrer, i_agent in itertools.product(range(2), range(2))
                 ]
             )
 

--- a/vega_sim/service.py
+++ b/vega_sim/service.py
@@ -2551,6 +2551,7 @@ class VegaService(ABC):
         time_in_force: Optional[Union[vega_protos.vega.Order.TimeInForce, str]] = None,
         pegged_offset: Optional[float] = None,
         pegged_reference: Optional[Union[vega_protos.vega.PeggedReference, str]] = None,
+        round_to_tick: bool = True,
     ) -> OrderAmendment:
         """Creates a Vega OrderAmendment object.
 
@@ -2580,13 +2581,12 @@ class VegaService(ABC):
                 The created Vega OrderAmendment object
         """
 
-        price = (
-            price
-            if price is None
-            else num_to_padded_int(
-                to_convert=price, decimals=self.market_price_decimals[market_id]
+        if round_to_tick:
+            market = self.data_cache.market_from_feed(market_id)
+            price = helpers.round_to_tick(
+                price=price,
+                tick_size=market.tick_size,
             )
-        )
 
         pegged_offset = (
             pegged_offset

--- a/vega_sim/vegahome/config/node/config.toml
+++ b/vega_sim/vegahome/config/node/config.toml
@@ -3,7 +3,7 @@ NodeMode = "validator"
 UlimitNOFile = 8192
 
 [API]
-  Level = "Debug"
+  Level = "Info"
   Timeout = "5s"
   Port = "TO_BE_SET"
   IP = "0.0.0.0"
@@ -23,7 +23,7 @@ UlimitNOFile = 8192
   LogOrderCancelDebug = false
   ChainProvider = "nullchain"
   [Blockchain.Tendermint]
-    Level = "Debug"
+    Level = "Info"
     LogTimeDebug = true
     ClientAddr = "tcp://0.0.0.0:26657"
     ClientEndpoint = "/websocket"
@@ -32,7 +32,7 @@ UlimitNOFile = 8192
     ABCIRecordDir = ""
     ABCIReplayFile = ""
   [Blockchain.Null]
-    Level = "Debug"
+    Level = "Info"
     BlockDuration = "TO_BE_SET"
     TransactionsPerBlock = "TO_BE_SET"
     GenesisFile = "./null-blockchain/node-startup/vegahome/genesis.json"
@@ -58,7 +58,7 @@ UlimitNOFile = 8192
   Delegations = true
 
 [Execution]
-  Level = "Debug"
+  Level = "Info"
   [Execution.Matching]
     Level = "Info"
     LogPriceLevelsDebug = false
@@ -77,7 +77,7 @@ UlimitNOFile = 8192
     Level = "Info"
 
 [Processor]
-  Level = "Debug"
+  Level = "Info"
   LogOrderSubmitDebug = true
   LogOrderAmendDebug = true
   LogOrderCancelDebug = true
@@ -130,7 +130,7 @@ UlimitNOFile = 8192
   Enabled = true
 
 [Governance]
-  Level = "Debug"
+  Level = "Info"
 
 [NodeWallet]
   Level = "Info"
@@ -154,7 +154,7 @@ UlimitNOFile = 8192
   Level = "Info"
 
 [Validators]
-  Level = "Debug"
+  Level = "Warning"
 
 [Banking]
   Level = "Info"
@@ -169,7 +169,7 @@ UlimitNOFile = 8192
   Level = "Info"
 
 [Checkpoint]
-  Level = "Info"
+  Level = "Warning"
 
 [Staking]
   Level = "Info"
@@ -198,7 +198,7 @@ UlimitNOFile = 8192
   Level = "Info"
 
 [Snapshot]
-  Level = "Info"
+  Level = "Warning"
   KeepRecent = 1000
   RetryLimit = 5
   Storage = "GOLevelDB"
@@ -206,7 +206,7 @@ UlimitNOFile = 8192
   StartHeight = 0
 
 [StateVar]
-  Level = "Info"
+  Level = "Warning"
 
 [Pprof]
   Level = "Info"


### PR DESCRIPTION
To reduce the memory usage of the fuzzing runs, PR...

- reduces number of fuzzing agents
- reduces number of fuzzed transactions

Also to reduce file size of core logs

- log level lowered too debug, failed runs can always be replayed on higher log level
- order amendments rounded to tick so logs are not filled with `ERROR - price not in tick size`