### PR TITLE
fix: stop market-marker self trading

### DIFF
--- a/vega_sim/api/trading.py
+++ b/vega_sim/api/trading.py
@@ -490,16 +490,16 @@ def order_amendment(
 
 
 def order_cancellation(
-    order_id: str,
-    market_id: str,
+    order_id: Optional[str] = None,
+    market_id: Optional[str] = None,
 ) -> OrderCancellation:
     """Creates a Vega OrderCancellation object.
 
     Args:
         order_id (str):
-            Id of order to cancel.
+            Id of order to cancel. Defaults to None.
         market_id (str):
-            Id of market containing order to cancel.
+            Id of market containing order to cancel. Defaults to None.
 
     Returns:
         OrderCancellation:

--- a/vega_sim/service.py
+++ b/vega_sim/service.py
@@ -2625,8 +2625,8 @@ class VegaService(ABC):
 
     def build_order_cancellation(
         self,
-        order_id: str,
-        market_id: str,
+        order_id: Optional[str] = None,
+        market_id: Optional[str] = None,
     ) -> OrderCancellation:
         """Returns a Vega OrderCancellation object
 
@@ -2635,9 +2635,9 @@ class VegaService(ABC):
 
         Args:
             order_id (str):
-                Id of order to cancel.
+                Id of order to cancel. Defaults to None.
             market_id (str):
-                Id of market containing order to cancel.
+                Id of market containing order to cancel. Defaults to None.
 
         Returns:
             OrderCancellation:


### PR DESCRIPTION
Recent overnight runs show the fuzzed markets frequently dipping in and out of auctions.

https://jenkins.vega.rocks/job/common/job/vega-market-sim-reinforcement/486/artifact/plots/2024-05-16%2001%3A18%3A02.025927/ETHUSDT-FUTR/price_monitoring_analysis.png

Checking benchmark runs locally (which the fuzzing runs inherit from)  we see…
- the orderbook is frequently thin.
- the exponential market-maker frequently has orders stopped for self trading. Why? 
  - If the datanode is lagging or market-sim is insufficiently synced, the MM may have an outdated view of orders to cancel/amend and may submit new orders which cross with exiting orders on the book.
  - benchmark market-makers provide liquidity at a tight spread to simplify configuring agents for different pairs (e.g. BTCUSDT, LDOUSDT), amend prices however are simply rounded to the nearest tick and frequently cross. This leaves buys and sells at the same tick.


Fix…
- market-makers now cancel all orders and then submit the entirety of the new shape in a single batch. The MM updates are now independent of whether the sim is synced or the tick size of the markets. Providing the new shape is not crossed, orders will never be stopped for self trading.
