### PR TITLE
fix: improving minting flow

### DIFF
--- a/vega_sim/api/data.py
+++ b/vega_sim/api/data.py
@@ -1718,6 +1718,7 @@ def list_accounts(
     pub_key: Optional[str] = None,
     asset_id: Optional[str] = None,
     market_id: Optional[str] = None,
+    account_types: Optional[vega_protos.vega.AccountType] = None,
     asset_decimals_map: Optional[Dict[str, int]] = None,
 ) -> List[AccountData]:
     """Output money in general accounts/margin accounts/bond accounts (if exists)
@@ -1726,6 +1727,7 @@ def list_accounts(
         data_client=data_client,
         party_id=pub_key,
         asset_id=asset_id,
+        account_types=account_types,
         market_id=market_id,
     )
 

--- a/vega_sim/api/data.py
+++ b/vega_sim/api/data.py
@@ -2371,9 +2371,6 @@ def list_transfers(
     for transfer_node in transfer_nodes:
         transfer = transfer_node.transfer
 
-        if transfer.status == events_protos.Transfer.Status.STATUS_REJECTED:
-            continue
-
         if transfer.asset not in asset_dp:
             asset_dp[transfer.asset] = get_asset_decimals(
                 asset_id=transfer.asset, data_client=data_client

--- a/vega_sim/api/data_raw.py
+++ b/vega_sim/api/data_raw.py
@@ -149,6 +149,7 @@ def list_accounts(
     data_client: vac.VegaTradingDataClientV2,
     asset_id: Optional[str] = None,
     market_id: Optional[str] = None,
+    account_types: Optional[vega_protos.vega.AccountType] = None,
     party_id: Optional[str] = None,
 ) -> List[data_node_protos_v2.trading_data.AccountBalance]:
     """
@@ -162,6 +163,8 @@ def list_accounts(
         account_filter.asset_id = asset_id
     if market_id is not None:
         account_filter.market_ids.extend([market_id])
+    if account_types is not None:
+        account_filter.account_types.extend(account_types)
     return unroll_v2_pagination(
         base_request=data_node_protos_v2.trading_data.ListAccountsRequest(
             filter=account_filter

--- a/vega_sim/api/faucet.py
+++ b/vega_sim/api/faucet.py
@@ -9,9 +9,12 @@ logger = getLogger(__name__)
 
 def mint(pub_key: str, asset: str, amount: int, faucet_url: str) -> None:
     url = BASE_MINT_URL.format(faucet_url=faucet_url)
+    # Request a proportion of the maximum faucet amount - this allows for
+    # cases where requesting the maximum amount would have floating point
+    # imprecision and the request rejected.
     payload = {
         "party": pub_key,
-        "amount": str(int(amount)),
+        "amount": str(int(0.99 * amount)),
         "asset": asset,
     }
     for i in range(20):

--- a/vega_sim/environment/environment.py
+++ b/vega_sim/environment/environment.py
@@ -40,8 +40,6 @@ from vega_sim.network_service import VegaServiceNetwork
 from vega_sim.null_service import VegaServiceNull
 from vega_sim.service import VegaService
 
-from vega_sim.service import VegaFaucetError
-
 logger = logging.getLogger(__name__)
 
 MarketState = namedtuple(
@@ -304,16 +302,8 @@ class MarketEnvironment:
             if self.random_agent_ordering
             else self.agents
         ):
-            # TODO: Remove this once fauceting error has been investigated
-            try:
-                agent.step(vega)
-            except VegaFaucetError:
-                logger.exception(
-                    f"Agent {agent.name()} failed to step. Funds from faucet never"
-                    " received."
-                )
-                # Mint forwards blocks, wait for catchup
-                vega.wait_for_total_catchup()
+            agent.step(vega)
+            vega.wait_for_total_catchup()
 
 
 class MarketEnvironmentWithState(MarketEnvironment):
@@ -431,16 +421,7 @@ class MarketEnvironmentWithState(MarketEnvironment):
             if self.random_agent_ordering
             else self.agents
         ):
-            # TODO: Remove this once fauceting error has been investigated
-            try:
-                agent.step(state)
-            except VegaFaucetError:
-                logger.exception(
-                    f"Agent {agent.name()} failed to step. Funds from faucet never"
-                    " received."
-                )
-                # Mint forwards blocks, wait for catchup
-                vega.wait_for_total_catchup()
+            agent.step(state)
 
 
 class NetworkEnvironment(MarketEnvironmentWithState):

--- a/vega_sim/local_data_cache.py
+++ b/vega_sim/local_data_cache.py
@@ -453,14 +453,12 @@ class LocalDataCache:
     def initialise_transfer_monitoring(
         self,
     ):
-        base_transfers = []
-
-        base_transfers.extend(
-            data.list_transfers(data_client=self._trading_data_client)
-        )
+        base_transfers = data.list_transfers(data_client=self._trading_data_client)
 
         with self.transfers_lock:
             for t in base_transfers:
+                if t.status != events_protos.Transfer.Status.STATUS_REJECTED:
+                    continue
                 self._transfer_state_from_feed.setdefault(t.party_to, {})[t.id] = t
 
     def initialise_network_parameters(self):

--- a/vega_sim/local_data_cache.py
+++ b/vega_sim/local_data_cache.py
@@ -457,7 +457,7 @@ class LocalDataCache:
 
         with self.transfers_lock:
             for t in base_transfers:
-                if t.status != events_protos.Transfer.Status.STATUS_REJECTED:
+                if t.status == events_protos.Transfer.Status.STATUS_REJECTED:
                     continue
                 self._transfer_state_from_feed.setdefault(t.party_to, {})[t.id] = t
 

--- a/vega_sim/null_service.py
+++ b/vega_sim/null_service.py
@@ -1028,19 +1028,7 @@ class VegaServiceNull(VegaService):
 
         # Initialise the data-cache
         self.data_cache
-
-        # Create the VegaService key and mint assets to the treasury
-        governance_asset = self.get_asset(
-            self.find_asset_id(symbol="VOTE", enabled=True, raise_on_missing=True)
-        )
         self.wallet.create_key(wallet_name=self.WALLET_NAME, name=self.KEY_NAME)
-        self.mint(
-            wallet_name=self.WALLET_NAME,
-            key_name=self.KEY_NAME,
-            asset=governance_asset.id,
-            amount=governance_asset.details.builtin_asset.max_faucet_amount_mint,
-            from_faucet=True,
-        )
 
     # Class internal as at some point the host may vary as well as the port
     @staticmethod

--- a/vega_sim/scenario/common/agents.py
+++ b/vega_sim/scenario/common/agents.py
@@ -1310,7 +1310,6 @@ class ShapedMarketMaker(StateAgentWithWallet):
                         asset=self.asset_id,
                         amount=self.initial_asset_mint,
                         key_name=self.key_name,
-                        raise_error=False,
                     )
                     self.vega.wait_for_total_catchup()
 
@@ -3271,7 +3270,6 @@ class UncrossAuctionAgent(StateAgentWithWallet):
                         asset=self.asset_id,
                         amount=self.initial_asset_mint,
                         key_name=self.key_name,
-                        raise_error=False,
                     )
 
             # Ensure volume maximising range is at least 100bps wide to

--- a/vega_sim/scenario/fuzzed_markets/agents.py
+++ b/vega_sim/scenario/fuzzed_markets/agents.py
@@ -298,7 +298,6 @@ class FuzzingAgent(StateAgentWithWallet):
             wallet_name=self.wallet_name,
             asset=asset_id,
             amount=amount,
-            raise_error=False,
         )
 
 
@@ -364,7 +363,6 @@ class RiskyMarketOrderTrader(StateAgentWithWallet):
                 wallet_name=self.wallet_name,
                 amount=self.initial_asset_mint,
                 asset=self.asset_id,
-                raise_error=False,
             )
             self.close_outs += 1
             self.commitment_amount = 0
@@ -466,7 +464,6 @@ class RiskySimpleLiquidityProvider(StateAgentWithWallet):
                 wallet_name=self.wallet_name,
                 amount=self.initial_asset_mint,
                 asset=self.asset_id,
-                raise_error=False,
             )
             self.close_outs += 1
             self.commitment_amount = 0
@@ -639,7 +636,6 @@ class FuzzyLiquidityProvider(StateAgentWithWallet):
                 wallet_name=self.wallet_name,
                 amount=self.initial_asset_mint,
                 asset=self.asset_id,
-                raise_error=False,
             )
             return
 

--- a/vega_sim/service.py
+++ b/vega_sim/service.py
@@ -1832,6 +1832,7 @@ class VegaService(ABC):
         wallet_name: Optional[str] = None,
         asset_id: Optional[str] = None,
         market_id: Optional[str] = None,
+        account_types: Optional[List[vega_protos.vega.AccountType.Value]] = None,
         key_name: Optional[str] = None,
     ) -> List[data.AccountData]:
         """Return all accounts across markets matching the supplied filter options
@@ -1843,6 +1844,8 @@ class VegaService(ABC):
                 Optional, default None, Filter down to only accounts on this asset
             market_id:
                 Optional, default None, Filter down to only accounts from this market
+            account_types:
+                Optional, default None, Filter down to only accounts of these type
             key_name:
                 Optional, default None, Select non-default key from the selected wallet
 
@@ -1859,6 +1862,7 @@ class VegaService(ABC):
             ),
             asset_id=asset_id,
             market_id=market_id,
+            account_types=account_types,
             asset_decimals_map=self.asset_decimals,
         )
 

--- a/vega_sim/service.py
+++ b/vega_sim/service.py
@@ -510,14 +510,14 @@ class VegaService(ABC):
             amount=asset_details.builtin_asset.max_faucet_amount_mint,
             faucet_url=self.faucet_url,
         )
-        for _ in range(60):
-            time.sleep(1)
+        for i in range(400):
+            time.sleep(0.01 * 1.01**i)
             self.wait_fn(1)
             self.wait_for_total_catchup()
             post_balance = get_treasury_balance(asset_id)
             if post_balance > pre_balance:
                 logging.debug(
-                    f"Successfully topped up treasury with maximum amount of asset {asset_id}."
+                    f"Successfully topped up treasury with maximum amount of asset {asset_details.symbol} after {i} blocks."
                 )
                 return
         raise VegaTopUpError(

--- a/vega_sim/service.py
+++ b/vega_sim/service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import uuid
 import copy
 import datetime
 import logging
@@ -102,7 +103,7 @@ class DatanodeSlowResponseError(Exception):
     pass
 
 
-class VegaFaucetError(Exception):
+class VegaTopUpError(Exception):
     pass
 
 
@@ -486,75 +487,110 @@ class VegaService(ABC):
         """
         return self.wallet.create_key(wallet_name=wallet_name, name=name)
 
+    def top_up_treasury(self, asset_id: str) -> None:
+
+        def get_treasury_balance(asset_id: str) -> float:
+            try:
+                return self.list_accounts(
+                    key_name=self.KEY_NAME,
+                    wallet_name=self.WALLET_NAME,
+                    asset_id=asset_id,
+                    account_types=[vega_protos.vega.AccountType.ACCOUNT_TYPE_GENERAL],
+                )[0].balance
+            except IndexError:
+                return 0
+
+        pre_balance = get_treasury_balance(asset_id)
+        asset_details = self.get_asset(asset_id).details
+        faucet.mint(
+            pub_key=self.wallet.public_key(
+                wallet_name=self.WALLET_NAME, name=self.KEY_NAME
+            ),
+            asset=asset_id,
+            amount=asset_details.builtin_asset.max_faucet_amount_mint,
+            faucet_url=self.faucet_url,
+        )
+        for _ in range(60):
+            time.sleep(1)
+            self.wait_fn(1)
+            self.wait_for_total_catchup()
+            post_balance = get_treasury_balance(asset_id)
+            if post_balance > pre_balance:
+                logging.debug(
+                    f"Successfully topped up treasury with maximum amount of asset {asset_id}."
+                )
+                return
+        raise VegaTopUpError(
+            f"Funds never appeared in treasury account. Pre-Balance: {pre_balance}, Post-Balance: {post_balance}"
+        )
+
     def mint(
         self,
-        key_name: Optional[str],
+        key_name: str,
         asset: str,
         amount: float,
         wallet_name: Optional[str] = None,
-        from_faucet: bool = False,
-        raise_error: bool = True,
     ) -> None:
-        """Mints a given amount of requested asset into the associated wallet.
 
-        Default behaviour is to transfer funds from the Vega Service "treasury", to mint
-        funds directly from the faucet the optional from_faucet arg can be set.
-
-        Args:
-            wallet_name:
-                str, The name of the wallet
-            asset:
-                str, The ID of the asset to mint
-            amount:
-                float, the amount of asset to mint
-            key_name:
-                Optional[str], key name stored in metadata. Defaults to None.
-        """
-        curr_acct = self.party_account(
-            wallet_name=wallet_name, asset_id=asset, key_name=key_name
-        ).general
-
-        if from_faucet:
-            faucet.mint(
-                self.wallet.public_key(wallet_name=wallet_name, name=key_name),
-                asset,
-                num_to_padded_int(amount, self.asset_decimals[asset]),
-                faucet_url=self.faucet_url,
-            )
-        else:
-            self.one_off_transfer(
-                from_wallet_name=self.WALLET_NAME,
-                from_key_name=self.KEY_NAME,
-                from_account_type=vega_protos.vega.ACCOUNT_TYPE_GENERAL,
-                to_account_type=vega_protos.vega.ACCOUNT_TYPE_GENERAL,
-                asset=asset,
-                amount=amount,
-                to_key_name=key_name,
-                to_wallet_name=wallet_name,
-            )
-
-        self.wait_fn(1)
-        self.wait_for_total_catchup()
-
-        for i in range(100):
-            time.sleep(0.05 * 1.03**i)
-            self.data_cache.initialise_accounts()
-            post_acct = self.party_account(
-                wallet_name=wallet_name,
-                asset_id=asset,
-                key_name=key_name,
-            ).general
-            if post_acct > curr_acct:
-                return
-            self.wait_fn(1)
-
-        err = VegaFaucetError(
-            f"Failure minting asset {asset} for party {wallet_name}. Funds never"
-            " appeared in party account"
+        # Calculate the required funds including any transfer fee.
+        required_treasury_funds = amount * (
+            1 + float(self.network_parameter_from_feed("transfer.fee.factor").value)
         )
-        if raise_error:
-            raise err
-        logger.error(err)
+
+        # Iteratively check whether the treasury has sufficient balance
+        # to top up the party. If not, top up the treasury first with
+        # the assets maximum faucet amount.
+        i = 0
+        while (
+            self.party_account(
+                key_name=self.KEY_NAME, wallet_name=self.WALLET_NAME, asset_id=asset
+            ).general
+            < required_treasury_funds
+        ):
+            if i > 100:
+                raise VegaTopUpError(
+                    f"Attempted to top up treasury too many times. Unable to top up party with {required_treasury_funds} funds."
+                )
+            logger.debug(
+                f"Insufficient funds in treasury to top up party (with {required_treasury_funds}). Topping up treasury."
+            )
+            self.top_up_treasury(asset)
+            i += 1
+
+        # Create a transfer with a unique reference to top up the party.
+        reference = str(uuid.uuid4())
+        self.one_off_transfer(
+            from_wallet_name=self.WALLET_NAME,
+            from_key_name=self.KEY_NAME,
+            to_wallet_name=wallet_name,
+            to_key_name=key_name,
+            from_account_type=vega_protos.vega.AccountType.ACCOUNT_TYPE_GENERAL,
+            to_account_type=vega_protos.vega.AccountType.ACCOUNT_TYPE_GENERAL,
+            asset=asset,
+            amount=amount,
+            reference=reference,
+        )
+        for _ in range(100):
+            self.wait_fn(1)
+            self.wait_for_total_catchup()
+            transfers = self.list_transfers(
+                wallet_name=wallet_name,
+                key_name=key_name,
+                direction=data_node_protos_v2.trading_data.TransferDirection.TRANSFER_DIRECTION_TRANSFER_TO,
+            )
+            for transfer in transfers:
+                if transfer.reference == reference:
+                    if (
+                        transfer.status
+                        == vega_protos.events.v1.events.Transfer.Status.STATUS_DONE
+                    ):
+                        return
+                    raise VegaTopUpError(
+                        f"Internal 'top-up' transfer ({reference}) failed with status '{vega_protos.events.v1.events.Transfer.Status.Name(transfer.status)}' and reason '{transfer.reason}'."
+                    )
+        raise VegaTopUpError(
+            f"Internal 'top-up' transfer ({reference}) never reached network."
+        )
 
     def forward(self, time: str) -> None:
         """Steps chain forward a given amount of time, either with an amount of time or
@@ -626,17 +662,6 @@ class VegaService(ABC):
         )
         self.wait_fn(60)
         self.wait_for_thread_catchup()
-
-        asset_id = self.find_asset_id(
-            symbol=symbol, enabled=True, raise_on_missing=True
-        )
-        self.mint(
-            wallet_name=self.WALLET_NAME,
-            key_name=self.KEY_NAME,
-            asset=asset_id,
-            amount=max_faucet_amount,
-            from_faucet=True,
-        )
 
     def create_market_from_config(
         self,


### PR DESCRIPTION
## Summary 

Current minting method is flaky as there is no guarantee the balance after minting will be greater than the balance before minting, even if the mint is successful. This is as minting directly from the faucet or through transfers requires blocks to be forwarded in which funds can flow out for reasons independent of any flows in. 

Instead...
- we can faucet to the treasury when needed as the treasury balance should be fairly static (i.e. no flows out other than top-up transfers).
- and top-up parties through transfers but crucially check the status of the transfer rather than the account balance.

New minting flow is as follows….

1. Check treasury has enough funds to cover the full “top up” transfer, if not iteratively...
    1. Faucet maximum funds directly to the treasury. 
    1. If funds never arrived raise error.
1. Make an internal “top up” transfer from the treasury to the party with a unique reference. Then..
    1. Forward a block
    1. Wait for synchronisation
    1. Query transfers, checking if transfer is successful. Note we do not care if the balance increased, only that the top up was successful.
    1. If the transfer was rejected raise error.
1. If transfer never appeared raise error.