### PR TITLE
feat: fix plugin version

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -1,7 +1,7 @@
 ---
 version: v1
 plugins:
-  - plugin: buf.build/protocolbuffers/python
+  - plugin: buf.build/protocolbuffers/python:v26.1
     opt: pyi_out
     out: ./vega_sim/proto
   - plugin: buf.build/grpc/python


### PR DESCRIPTION
Fixes version of buf plugins to `v26.1`

```
buf.build/protocolbuffers/python:v26.1
```