### PR TITLE
feat: transaction reordering checks

### DIFF
--- a/vega_sim/api/market.py
+++ b/vega_sim/api/market.py
@@ -155,6 +155,7 @@ class SpotMarketConfig(Config):
             "liquidity_sla_parameters": "default",
             "liquidity_fee_settings": "default",
             "tick_size": "2",
+            "enable_transaction_reordering": True,
         },
     }
 
@@ -180,6 +181,7 @@ class SpotMarketConfig(Config):
         self.liquidity_fee_settings = LiquidityFeeSettings(
             opt=config["liquidity_fee_settings"]
         )
+        self.enable_transaction_reordering = config["enable_transaction_reordering"]
 
     def build(self, oracle_pubkey: str):
         new_spot_market = vega_protos.governance.NewSpotMarket(
@@ -194,6 +196,7 @@ class SpotMarketConfig(Config):
                 liquidity_fee_settings=self.liquidity_fee_settings.build(),
                 tick_size=str(self.tick_size),
                 metadata=self.metadata,
+                enable_transaction_reordering=self.enable_transaction_reordering,
             )
         )
         return new_spot_market

--- a/vega_sim/configs/research/fcap/ENGFRA_POS.py
+++ b/vega_sim/configs/research/fcap/ENGFRA_POS.py
@@ -61,11 +61,11 @@ CONFIG = MarketConfig(
                     "settlementDataProperty": "prices.engfra.value",
                     "tradingTerminationProperty": "termination",
                 },
-                # "cap": {
-                #     "maxPrice": 1000000,
-                #     "binarySettlement": False,
-                #     "fullyCollateralised": True,
-                # },
+                "cap": {
+                    "maxPrice": 1000000,
+                    "binarySettlement": False,
+                    "fullyCollateralised": True,
+                },
             },
         },
         "metadata": [
@@ -104,5 +104,6 @@ CONFIG = MarketConfig(
         "markPriceConfiguration": {
             "compositePriceType": "COMPOSITE_PRICE_TYPE_LAST_TRADE",
         },
+        "enableTransactionReordering": False,
     }
 )

--- a/vega_sim/configs/research/fcap/ENGFRA_RES.py
+++ b/vega_sim/configs/research/fcap/ENGFRA_RES.py
@@ -105,5 +105,6 @@ CONFIG = MarketConfig(
         "markPriceConfiguration": {
             "compositePriceType": "COMPOSITE_PRICE_TYPE_LAST_TRADE",
         },
+        "enableTransactionReordering": True,
     }
 )

--- a/vega_sim/configs/research/futr/BTCUSDT.py
+++ b/vega_sim/configs/research/futr/BTCUSDT.py
@@ -123,5 +123,6 @@ CONFIG = MarketConfig(
         "markPriceConfiguration": {
             "compositePriceType": "COMPOSITE_PRICE_TYPE_LAST_TRADE",
         },
+        "enableTransactionReordering": True,
     }
 )

--- a/vega_sim/configs/research/futr/ETHUSDT.py
+++ b/vega_sim/configs/research/futr/ETHUSDT.py
@@ -123,5 +123,6 @@ CONFIG = MarketConfig(
         "markPriceConfiguration": {
             "compositePriceType": "COMPOSITE_PRICE_TYPE_LAST_TRADE",
         },
+        "enableTransactionReordering": False,
     }
 )

--- a/vega_sim/configs/research/perp/BTCUSDT.py
+++ b/vega_sim/configs/research/perp/BTCUSDT.py
@@ -258,5 +258,6 @@ CONFIG = MarketConfig(
                 {"priceSourceProperty": "btc.price"},
             ],
         },
+        "enableTransactionReordering": True,
     }
 )

--- a/vega_sim/configs/research/perp/ETHUSDT.py
+++ b/vega_sim/configs/research/perp/ETHUSDT.py
@@ -258,5 +258,6 @@ CONFIG = MarketConfig(
                 {"priceSourceProperty": "eth.price"},
             ],
         },
+        "enableTransactionReordering": False,
     }
 )

--- a/vega_sim/configs/research/spot/BTCETH.py
+++ b/vega_sim/configs/research/spot/BTCETH.py
@@ -59,5 +59,6 @@ CONFIG = SpotMarketConfig(
             "slaCompetitionFactor": "0.8",
         },
         "liquidityFeeSettings": {"method": "METHOD_MARGINAL_COST"},
+        "enableTransactionReordering": True,
     },
 )

--- a/vega_sim/configs/research/spot/BTCUSDT.py
+++ b/vega_sim/configs/research/spot/BTCUSDT.py
@@ -59,5 +59,6 @@ CONFIG = SpotMarketConfig(
             "slaCompetitionFactor": "0.8",
         },
         "liquidityFeeSettings": {"method": "METHOD_MARGINAL_COST"},
+        "enableTransactionReordering": True,
     },
 )

--- a/vega_sim/configs/research/spot/ETHUSDT.py
+++ b/vega_sim/configs/research/spot/ETHUSDT.py
@@ -59,5 +59,6 @@ CONFIG = SpotMarketConfig(
             "slaCompetitionFactor": "0.8",
         },
         "liquidityFeeSettings": {"method": "METHOD_MARGINAL_COST"},
+        "enableTransactionReordering": False,
     },
 )

--- a/vega_sim/scenario/fuzzing/scenario.py
+++ b/vega_sim/scenario/fuzzing/scenario.py
@@ -14,6 +14,7 @@ from vega_sim.scenario.common.agents import (
     StateAgent,
     RewardFunder,
     ReferralAgentWrapper,
+    TransactionDelayChecker,
 )
 from vega_sim.scenario.fuzzed_markets.agents import (
     FuzzingAgent,
@@ -160,6 +161,16 @@ class FuzzingScenario(BenchmarkScenario):
             #         for i_referrer, i_agent in itertools.product(range(2), range(2))
             #     ]
             # )
+            extra_agents.append(
+                TransactionDelayChecker(
+                    wallet_name="TransactionDelayChecker",
+                    key_name=(f"TransactionDelayChecker_{market_code}"),
+                    market_name=market_name,
+                    initial_asset_mint=1e6,
+                    tag=f"{market_code}",
+                    transaction_reordering_enabled=benchmark_config.market_config.enable_transaction_reordering,
+                )
+            )
 
         # Create a reward funder for each asset and each reward type
         asset_names = set()


### PR DESCRIPTION
## Summary

Rather than defaulting all markets to use reordering, PR switches fuzzing run to have at least one market with reordering enabled and one with reordering disabled for each product type (FUTR, FCAP, PERP, SPOT).

A new agent is added to check whether reordering is working correctly.

1. Agent submits an aggressive order
2. Agent submits a passive order

Continue sim execution and once both orders appear on the book, if...

- transaction reordering enabled, check aggressive order created after passive order (i.e. later block)
- transaction reordering disabled, check aggressive order created at same time as passive order (i.e. same block)

Fuzzing runs not capable of checking reordering of cancellations, passive transactions, and aggressive transactions as the sequence in which orders are executed within a block cannot be checked through APIs.
