### PR TITLE
chore: enable amm fuzzing

### DIFF
--- a/vega_sim/scenario/fuzzing/scenario.py
+++ b/vega_sim/scenario/fuzzing/scenario.py
@@ -140,27 +140,27 @@ class FuzzingScenario(BenchmarkScenario):
                     for i_referrer, i_agent in itertools.product(range(2), range(2))
                 ]
             )
-            # extra_agents.extend(
-            #     [
-            #         ReferralAgentWrapper(
-            #             agent=FuzzedAutomatedMarketMaker(
-            #                 wallet_name="FuzzedAutomatedMarketMaker",
-            #                 key_name=(
-            #                     f"FuzzedAutomatedMarketMaker{str(i_referrer).zfill(3)}_{str(i_agent).zfill(3)}"
-            #                 ),
-            #                 market_name=market_name,
-            #                 submit_probability=0.5,
-            #                 amend_probability=0.5,
-            #                 cancel_probability=0.1,
-            #                 initial_asset_mint=1e6,
-            #                 tag=f"{market_code}_{str(i_referrer).zfill(3)}_{str(i_agent).zfill(3)}",
-            #             ),
-            #             referrer_wallet_name="ReferralAgentWrapper",
-            #             referrer_key_name=f"ReferralAgentWrapper_{str(i_referrer).zfill(3)}",
-            #         )
-            #         for i_referrer, i_agent in itertools.product(range(2), range(2))
-            #     ]
-            # )
+            extra_agents.extend(
+                [
+                    ReferralAgentWrapper(
+                        agent=FuzzedAutomatedMarketMaker(
+                            wallet_name="FuzzedAutomatedMarketMaker",
+                            key_name=(
+                                f"FuzzedAutomatedMarketMaker{str(i_referrer).zfill(3)}_{str(i_agent).zfill(3)}"
+                            ),
+                            market_name=market_name,
+                            submit_probability=0.5,
+                            amend_probability=0.5,
+                            cancel_probability=0.1,
+                            initial_asset_mint=1e6,
+                            tag=f"{market_code}_{str(i_referrer).zfill(3)}_{str(i_agent).zfill(3)}",
+                        ),
+                        referrer_wallet_name="ReferralAgentWrapper",
+                        referrer_key_name=f"ReferralAgentWrapper_{str(i_referrer).zfill(3)}",
+                    )
+                    for i_referrer, i_agent in itertools.product(range(2), range(2))
+                ]
+            )
             extra_agents.append(
                 TransactionDelayChecker(
                     wallet_name="TransactionDelayChecker",


### PR DESCRIPTION
Fuzzing has previously been disabled in overnight runs as blocked by panics.

Recent fixes allow full green funs with AMMs hence PR now enables AMM fuzzing on overnight runs.