### PR TITLE
fix: ensure catchup for failing market state tests

### DIFF
--- a/tests/integration/test_update_market.py
+++ b/tests/integration/test_update_market.py
@@ -201,6 +201,7 @@ def test_update_market_governance_changes(vega_service_with_market: VegaServiceN
         MM_WALLET.name,
         MarketStateUpdateType.Suspend,
     )
+    vega.wait_fn(1)
     vega.wait_for_total_catchup()
     assert (
         vega_protos.markets.Market.State.Name(


### PR DESCRIPTION
Replaying failing tests shows market is in correct state.

Tests are therefore failing as datanode does reflect the state expected. This could either be because datanode has not finished processing the final event, or core has not finished processing the final block.

Whilst the former is fairly well tested, the later is extremely hard to ensure as the wallet can be asynchronously sending transactions to core.

PR simply adds a `wait_fn` which adds an additional final empty block which should be fast to process and we can wait for.