### PR TITLE
fix: market maker order spam rejections

### DIFF
--- a/vega_query/scripts/plots.py
+++ b/vega_query/scripts/plots.py
@@ -77,7 +77,7 @@ if __name__ == "__main__":
         if args.start_time is None
         else int(args.start_time.timestamp() * 1e9)
     )
-    market = service.utils.market.find_market([args.market])
+    market = service.utils.market.find_market([args.market], include_settled=True)
     if market.tradable_instrument.instrument.spot != protos.vega.markets.Spot():
         asset = service.utils.market.find_quote_asset([args.market])
     if market.tradable_instrument.instrument.future != protos.vega.markets.Future():

--- a/vega_query/service/utils/market.py
+++ b/vega_query/service/utils/market.py
@@ -31,7 +31,7 @@ class MarketUtils:
 
     def find_asset(self, substrings: List[str]) -> protos.vega.assets.Asset:
         instrument = self.find_market(
-            substrings=substrings
+            substrings=substrings, include_settled=True
         ).tradable_instrument.instrument
         if instrument.spot != protos.vega.markets.Spot():
             return self.find_quote_asset(substrings)
@@ -42,7 +42,8 @@ class MarketUtils:
 
     def find_base_asset(self, substrings: List[str]) -> protos.vega.assets.Asset:
         instrument = self.find_market(
-            substrings=substrings
+            substrings=substrings,
+            include_settled=True,
         ).tradable_instrument.instrument
         asset_id = None
         if instrument.spot != protos.vega.markets.Spot():
@@ -53,7 +54,8 @@ class MarketUtils:
 
     def find_quote_asset(self, substrings: List[str]) -> protos.vega.assets.Asset:
         instrument = self.find_market(
-            substrings=substrings
+            substrings=substrings,
+            include_settled=True,
         ).tradable_instrument.instrument
         asset_id = None
         if instrument.spot != protos.vega.markets.Spot():
@@ -65,11 +67,10 @@ class MarketUtils:
     def find_settlement_asset(
         self,
         substrings: List[str],
-        include_settled: bool = False,
     ) -> protos.vega.assets.Asset:
         instrument = self.find_market(
             substrings=substrings,
-            include_settled=include_settled,
+            include_settled=True,
         ).tradable_instrument.instrument
         asset_id = None
         if instrument.future != protos.vega.markets.Future():
@@ -81,7 +82,11 @@ class MarketUtils:
         raise Exception("Market is not a future or perpetual market.")
 
     def find_size_decimals(self, substrings: List[str]) -> int:
-        return self.find_market(substrings=substrings).position_decimal_places
+        return self.find_market(
+            substrings=substrings, include_settled=True
+        ).position_decimal_places
 
     def find_price_decimals(self, substrings: List[str]) -> int:
-        return self.find_market(substrings=substrings).decimal_places
+        return self.find_market(
+            substrings=substrings, include_settled=True
+        ).decimal_places

--- a/vega_query/visualisations/overlay.py
+++ b/vega_query/visualisations/overlay.py
@@ -44,6 +44,7 @@ def overlay_last_traded_price(
     ax: Axes,
     market_data_history: List[protos.vega.vega.MarketData],
     price_decimals: int,
+    **kwargs,
 ):
     x = []
     y = []
@@ -51,7 +52,7 @@ def overlay_last_traded_price(
         x.append(timestamp_to_datetime(market_data.timestamp, nano=True))
         price = padded_int_to_float(market_data.last_traded_price, price_decimals)
         y.append(price if price != 0 else np.nan)
-    ax.step(x, y, label="last_traded_price", where="post")
+    ax.step(x, y, label="last_traded_price", where="post", **kwargs)
 
 
 def overlay_indicative_price(
@@ -72,6 +73,7 @@ def overlay_best_bid_price(
     ax: Axes,
     market_data_history: List[protos.vega.vega.MarketData],
     price_decimals: int,
+    **kwargs,
 ):
     x = []
     y = []
@@ -79,13 +81,29 @@ def overlay_best_bid_price(
         x.append(timestamp_to_datetime(market_data.timestamp, nano=True))
         price = padded_int_to_float(market_data.best_bid_price, price_decimals)
         y.append(price if price != 0 else np.nan)
-    ax.step(x, y, label="best_bid_price", where="post")
+    ax.step(x, y, label="best_bid_price", where="post", **kwargs)
+
+
+def overlay_best_bid_size(
+    ax: Axes,
+    market_data_history: List[protos.vega.vega.MarketData],
+    size_decimals: int,
+    **kwargs,
+):
+    x = []
+    y = []
+    for market_data in market_data_history:
+        x.append(timestamp_to_datetime(market_data.timestamp, nano=True))
+        size = padded_int_to_float(market_data.best_bid_volume, size_decimals)
+        y.append(size if size != 0 else np.nan)
+    ax.step(x, y, label="best_bid_size", where="post", **kwargs)
 
 
 def overlay_best_ask_price(
     ax: Axes,
     market_data_history: List[protos.vega.vega.MarketData],
     price_decimals: int,
+    **kwargs,
 ):
     x = []
     y = []
@@ -93,7 +111,22 @@ def overlay_best_ask_price(
         x.append(timestamp_to_datetime(market_data.timestamp, nano=True))
         price = padded_int_to_float(market_data.best_offer_price, price_decimals)
         y.append(price if price != 0 else np.nan)
-    ax.step(x, y, label="best_ask_price", where="post")
+    ax.step(x, y, label="best_ask_price", where="post", **kwargs)
+
+
+def overlay_best_ask_size(
+    ax: Axes,
+    market_data_history: List[protos.vega.vega.MarketData],
+    size_decimals: int,
+    **kwargs,
+):
+    x = []
+    y = []
+    for market_data in market_data_history:
+        x.append(timestamp_to_datetime(market_data.timestamp, nano=True))
+        size = padded_int_to_float(market_data.best_offer_volume, size_decimals)
+        y.append(size if size != 0 else np.nan)
+    ax.step(x, y, label="best_ask_size", where="post", **kwargs)
 
 
 def overlay_price_bounds(

--- a/vega_query/visualisations/plots/amm.py
+++ b/vega_query/visualisations/plots/amm.py
@@ -40,7 +40,7 @@ def create(
 ):
 
     # Get market, asset, and network parameter information
-    market = service.utils.market.find_market([market_code])
+    market = service.utils.market.find_market([market_code], include_settled=True)
     asset = service.utils.market.find_asset([market_code])
     epoch_length = duration_str_to_int(
         service.api.data.get_network_parameter(key="validators.epoch.length").value

--- a/vega_query/visualisations/plots/sla.py
+++ b/vega_query/visualisations/plots/sla.py
@@ -43,7 +43,7 @@ def create(
 ):
 
     # Get market, asset, and network parameter information
-    market = service.utils.market.find_market([market_code])
+    market = service.utils.market.find_market([market_code], include_settled=True)
     asset = service.utils.market.find_asset([market_code])
     epoch_length = duration_str_to_int(
         service.api.data.get_network_parameter(key="validators.epoch.length").value

--- a/vega_sim/scenario/benchmark/scenario.py
+++ b/vega_sim/scenario/benchmark/scenario.py
@@ -109,7 +109,7 @@ class BenchmarkScenario(Scenario):
             self.agents.append(
                 ExponentialShapedMarketMaker(
                     wallet_name="ExponentialShapedMarketMaker",
-                    key_name="ExponentialShapedMarketMaker",
+                    key_name=f"ExponentialShapedMarketMaker_{benchmark_config.market_config.instrument.code}",
                     price_process_generator=iter(benchmark_config.price_process),
                     initial_asset_mint=1e9,
                     market_name=market_name,

--- a/vega_sim/vegahome/genesis.json
+++ b/vega_sim/vegahome/genesis.json
@@ -212,6 +212,8 @@
       "spam.protection.proposal.min.tokens": "2000000000000000000000",
       "spam.protection.voting.min.tokens": "1000000000000000000",
       "spam.protection.applyReferral.min.funds": "0",
+      "spam.order.minimumMarginQuantumMultiple": "0",
+      "spam.order.minimumHoldingQuantumMultiple": "0",
       "transfer.fee.factor": "0.001",
       "transfer.minTransferQuantumMultiple": "0",
       "transfer.fee.maxQuantumAmount": "100",

--- a/vega_sim/wallet/slim_wallet.py
+++ b/vega_sim/wallet/slim_wallet.py
@@ -119,6 +119,9 @@ class SlimWallet(Wallet):
             self.pub_keys[wallet_name] = {}
 
         if self.vega_wallet is None:
+            if name in self.keys[wallet_name] and name in self.pub_keys[wallet_name]:
+                return
+
             self.keys[wallet_name][name] = SigningKey.generate()
             self.pub_keys[wallet_name][name] = (
                 self.keys[wallet_name][name]


### PR DESCRIPTION
In current fuzzing runs MM batch orders are intermittently rejected.

PR switches so the primary MM has a unique key per market to avoid batches being rejected when multiple markets are running in parrallel.